### PR TITLE
[ List ] fix: 멜론 차트 탐색 초점 오류

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		144FC6F32CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */; };
 		144FC6F52CBCD87300CC75FE /* BorderedListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */; };
 		144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */; };
-		144FC6FA2CBCE8B000CC75FE /* InnerCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */; };
+		144FC6FA2CBCE8B000CC75FE /* TodayCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -94,6 +94,8 @@
 		4ECD49842C8E9B6200F3BEC7 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 4ECD49832C8E9B6200F3BEC7 /* Base */; };
 		4ECD498E2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD498D2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift */; };
 		4ED71CE52CA6392F00A1A724 /* AccessibilityListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED71CE42CA6392F00A1A724 /* AccessibilityListCell.swift */; };
+		4EEEE6132CC0D9B500FCF08B /* ChartCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */; };
+		4EEEE6172CC0DC2500FCF08B /* LatestCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */; };
 		4EF982152C93E4DF00809294 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF982142C93E4DF00809294 /* AlertViewController.swift */; };
 		4EF982172C93FCDC00809294 /* AlertViewController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF982162C93FCDC00809294 /* AlertViewController+Action.swift */; };
 /* End PBXBuildFile section */
@@ -112,7 +114,7 @@
 		144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTextCellWithAccessibility.swift; sourceTree = "<group>"; };
 		144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderedListCell.swift; sourceTree = "<group>"; };
 		144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustableForAccessibility.swift; sourceTree = "<group>"; };
-		144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InnerCollectionListCell.swift; sourceTree = "<group>"; };
+		144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCollectionListCell.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -189,6 +191,8 @@
 		4ECD49852C8E9B6200F3BEC7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4ECD498D2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonAndSliderViewController.swift; sourceTree = "<group>"; };
 		4ED71CE42CA6392F00A1A724 /* AccessibilityListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityListCell.swift; sourceTree = "<group>"; };
+		4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartCollectionListCell.swift; sourceTree = "<group>"; };
+		4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestCollectionListCell.swift; sourceTree = "<group>"; };
 		4EF982142C93E4DF00809294 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		4EF982162C93FCDC00809294 /* AlertViewController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController+Action.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -224,7 +228,9 @@
 				144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */,
 				1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */,
 				1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */,
-				144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */,
+				144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */,
+				4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */,
+				4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */,
 			);
 			path = MelonChartNavigationViewControllerWithAccessibility;
 			sourceTree = "<group>";
@@ -653,6 +659,7 @@
 			files = (
 				144FC6F52CBCD87300CC75FE /* BorderedListCell.swift in Sources */,
 				144564282CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift in Sources */,
+				4EEEE6132CC0D9B500FCF08B /* ChartCollectionListCell.swift in Sources */,
 				4E0AB03F2C9BAB9700B8A89C /* Detail.swift in Sources */,
 				4E855F542CACE15C008CDB3B /* DefaultCollectionViewController.swift in Sources */,
 				4E855F582CACE1C0008CDB3B /* DefaultCollectionViewController+ListLayout.swift in Sources */,
@@ -693,7 +700,7 @@
 				4EC52B0C2CA19D57007E07D6 /* PresentationAndMenuViewController.swift in Sources */,
 				4E855F562CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift in Sources */,
 				4E1BC4F72CAF7244001A29D5 /* SearchViewController+Updating.swift in Sources */,
-				144FC6FA2CBCE8B000CC75FE /* InnerCollectionListCell.swift in Sources */,
+				144FC6FA2CBCE8B000CC75FE /* TodayCollectionListCell.swift in Sources */,
 				4EB122FA2CB7694300D771D3 /* NewsListCell.swift in Sources */,
 				4E285DBF2C8FE947007F286C /* ButtonAndSliderViewController+Action.swift in Sources */,
 				14F7FC422CB2C8DC00F3FA61 /* SearchViewControllerWithAccessibility+Delegate.swift in Sources */,
@@ -710,6 +717,7 @@
 				4E0AB0502C9BEF2800B8A89C /* SearchViewController.swift in Sources */,
 				4E12CE4B2CA2482F004DF1EA /* Titleable.swift in Sources */,
 				14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */,
+				4EEEE6172CC0DC2500FCF08B /* LatestCollectionListCell.swift in Sources */,
 				14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */,
 				4EC52AF52CA13925007E07D6 /* View+Constraints.swift in Sources */,
 				4EC52AE32C9D19D8007E07D6 /* SwitchViewController+Action.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
@@ -15,12 +15,10 @@ extension MelonChartNavigationViewController {
         cell.text = item
     }
     
-    func chartCellRegistrationHandler(cell: UICollectionViewCell, indexPath: IndexPath, item: String) {
-        var config = UIListContentConfiguration.valueCell()
-        config.text = item
-        cell.contentConfiguration = config
-        cell.contentView.layer.borderWidth = 1
-        cell.contentView.layer.borderColor = UIColor.black.cgColor
+    func chartCellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {
+        cell.rank = indexPath.item + 1
+        cell.text = item
+        cell.isAccessibilityElement = true
         
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
@@ -22,6 +22,13 @@ extension MelonChartNavigationViewController {
         
     }
     
+    func todayCellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {
+        cell.rank = indexPath.item + 1
+        cell.text = item
+        cell.isAccessibilityElement = true
+        
+    }
+    
     func supplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
         let title = snapshot.sectionIdentifiers[indexPath.section].title
         supplementaryView.title = title
@@ -30,11 +37,13 @@ extension MelonChartNavigationViewController {
     func updateSnapshot() {
         let latestItems = books.map{ Item(latest: $0.title) }
         let chartItems = books.map{ Item(chart: $0.title) }
+        let todayItems = books.map{ Item(today: $0.title) }
         
         snapshot = Snapshot()
-        snapshot.appendSections([.latest, .chart])
+        snapshot.appendSections([.latest, .chart, .today])
         snapshot.appendItems(latestItems, toSection: .latest)
         snapshot.appendItems(chartItems, toSection: .chart)
+        snapshot.appendItems(todayItems, toSection: .today)
         dataSource.apply(snapshot)
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+ListLayout.swift
@@ -51,7 +51,7 @@ extension MelonChartNavigationViewController {
     }
     
     func sectionForChart() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalHeight(0.9))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.93), heightDimension: .fractionalHeight(0.9))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .estimated(80))

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+ListLayout.swift
@@ -26,13 +26,15 @@ extension MelonChartNavigationViewController {
             return sectionForLatest()
         case .chart:
             return sectionForChart()
+        case .today:
+            return sectionForToday()
         }
     }
     
     func sectionForLatest() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.48))
         let nestedGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.48), heightDimension: .fractionalHeight(1.0))
-        let containerGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.95), heightDimension: .absolute(480))
+        let containerGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.95), heightDimension: .absolute(450))
         
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
@@ -62,6 +64,22 @@ extension MelonChartNavigationViewController {
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
         section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
         section.orthogonalScrollingBehavior = .groupPaging
+        
+        return section
+    }
+    
+    func sectionForToday() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.5))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .estimated(150))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 2)
+        group.interItemSpacing = .flexible(5)
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = 10
         
         return section
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Type.swift
@@ -11,14 +11,16 @@ import Foundation
 //MARK: Types for DataSource
 extension MelonChartNavigationViewController {
     enum Section: Int {
-        case latest, chart
+        case latest, chart, today
         
         var title: String {
             switch self {
             case .latest:
-                return "Latest"
+                return "최신 음악"
             case .chart:
-                return "Chart"
+                return "음악 차트"
+            case .today:
+                return "오늘의 음악"
             }
         }
     }
@@ -26,15 +28,24 @@ extension MelonChartNavigationViewController {
     struct Item: Hashable {
         let latest: String?
         let chart: String?
+        let today: String?
         
-        init(latest: String?) {
+        init(latest: String?, chart: String?, today: String?) {
             self.latest = latest
-            self.chart = nil
+            self.chart = chart
+            self.today = today
         }
         
-        init(chart: String?) {
-            self.chart = chart
-            self.latest = nil
+        init(latest: String) {
+            self.init(latest: latest, chart: nil, today: nil)
+        }
+        
+        init(chart: String) {
+            self.init(latest: nil, chart: chart, today: nil)
+        }
+        
+        init(today: String){
+            self.init(latest: nil, chart: nil, today: today)
         }
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
@@ -39,6 +39,7 @@ private extension MelonChartNavigationViewController {
     func configureDataSource() {
         let latestCellRegistration = UICollectionView.CellRegistration(handler: latestCellRegistrationHandler)
         let chartCellRegistration = UICollectionView.CellRegistration(handler: chartCellRegistrationHandler)
+        let todayCellRegistration = UICollectionView.CellRegistration(handler: todayCellRegistrationHandler)
         
         dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
             guard let section = Section(rawValue: indexPath.section) else {
@@ -49,6 +50,8 @@ private extension MelonChartNavigationViewController {
                 return collectionView.dequeueConfiguredReusableCell(using: latestCellRegistration, for: indexPath, item: itemIdentifier.latest)
             case .chart:
                 return collectionView.dequeueConfiguredReusableCell(using: chartCellRegistration, for: indexPath, item: itemIdentifier.chart)
+            case .today:
+                return collectionView.dequeueConfiguredReusableCell(using: todayCellRegistration, for: indexPath, item: itemIdentifier.today)
             }
         })
         

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/ChartCollectionListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/ChartCollectionListCell.swift
@@ -1,0 +1,86 @@
+//
+//  ChartCollectionListCell.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/17/24.
+//
+
+
+import UIKit
+
+final class ChartCollectionListCell: UICollectionViewCell {
+    
+    var dataSource: UICollectionViewDiffableDataSource<Int, String>!
+    var books = Book.samples
+    var currentPage = 0
+    
+    weak var delegate: AdjustableForAccessibility?
+    private var currentPageOfCustom = 0
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureContentView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func accessibilityIncrement() {
+        delegate?.adjustableIncrement(self)
+        
+    }
+    
+    override func accessibilityDecrement() {
+        delegate?.adjustableDecrement(self)
+    }
+}
+
+private extension ChartCollectionListCell {
+    
+    func configureContentView() {
+        let cellRegistration = UICollectionView.CellRegistration(handler: cellRegistrationHandler)
+        
+        dataSource = UICollectionViewDiffableDataSource<Int, String>(collectionView: collectionView) { collectionView,indexPath,itemIdentifier in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+        }
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Int, String>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(books.map({$0.title}))
+        dataSource.apply(snapshot)
+        collectionView.dataSource = dataSource
+        
+        contentView.addPinnedSubview(collectionView, height: nil)
+    }
+    
+    func layout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.93), heightDimension: .fractionalHeight(0.9))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .estimated(80))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 3)
+        group.interItemSpacing = .fixed(5)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.orthogonalScrollingBehavior = .groupPaging
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+    
+    func cellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {
+        cell.rank = indexPath.item + 1
+        cell.text = item
+    }
+    
+    func configureAccessibilityValue(current index: Int) {
+        let label = books[index].title
+        let value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
+        let descriptions = [label, value]
+        collectionView.accessibilityValue = descriptions.compactMap({ $0 }).joined(separator: ", ")
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/LatestCollectionListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/LatestCollectionListCell.swift
@@ -1,0 +1,89 @@
+//
+//  LatestCollectionListCell.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/17/24.
+//
+
+import UIKit
+
+final class LatestCollectionListCell: UICollectionViewCell {
+    
+    var dataSource: UICollectionViewDiffableDataSource<Int, String>!
+    var books = Book.samples
+    var currentPage = 0
+    
+    weak var delegate: AdjustableForAccessibility?
+    private var currentPageOfCustom = 0
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureContentView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func accessibilityIncrement() {
+        delegate?.adjustableIncrement(self)
+        
+    }
+    
+    override func accessibilityDecrement() {
+        delegate?.adjustableDecrement(self)
+    }
+}
+
+private extension LatestCollectionListCell {
+    
+    func configureContentView() {
+        let cellRegistration = UICollectionView.CellRegistration(handler: cellRegistrationHandler)
+        
+        dataSource = UICollectionViewDiffableDataSource<Int, String>(collectionView: collectionView) { collectionView,indexPath,itemIdentifier in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+        }
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Int, String>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(books.map({$0.title}))
+        dataSource.apply(snapshot)
+        collectionView.dataSource = dataSource
+        
+        contentView.addPinnedSubview(collectionView, height: nil)
+    }
+    
+    func layout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.48))
+        let nestedGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.48), heightDimension: .fractionalHeight(1.0))
+        let containerGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.95), heightDimension: .absolute(480))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let nestedGroup = NSCollectionLayoutGroup.vertical(layoutSize: nestedGroupSize, repeatingSubitem: item, count: 2)
+        nestedGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
+        
+        let containerGroup = NSCollectionLayoutGroup.horizontal(layoutSize: containerGroupSize, repeatingSubitem: nestedGroup, count: 2)
+        containerGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
+        
+        let section = NSCollectionLayoutSection(group: containerGroup)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.orthogonalScrollingBehavior = .continuous
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+    
+    func cellRegistrationHandler(cell: GridTextCellWithAccessibility, indexPath: IndexPath, item: String) {
+        cell.text = item
+    }
+    
+    func configureAccessibilityValue(current index: Int) {
+        let label = books[index].title
+        let value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
+        let descriptions = [label, value]
+        collectionView.accessibilityValue = descriptions.compactMap({ $0 }).joined(separator: ", ")
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
@@ -8,32 +8,6 @@
 import UIKit
 
 extension MelonChartNavigationViewControllerWithAccessibility {
-    func AccessibilityFrameForLatest(with cell: UICollectionViewCell, height: CGFloat, for state: AccessibilityFrameState) -> CGRect {
-        let originToView = collectionView.convert(cell.frame.origin, to: view)
-        let origin: CGPoint
-        switch state {
-        case .initial:
-            origin = CGPoint(x: originToView.x, y: originToView.y + collectionView.contentOffset.y - 10)
-        case .scroll:
-            origin = CGPoint(x: originToView.x, y: originToView.y)
-        }
-        let size = CGSize(width: view.frame.width - 20, height: cell.frame.height * height)
-        return CGRect(origin: origin, size: size)
-    }
-    
-    func AccessibilityFrameForChart(with cell: UICollectionViewCell, height: CGFloat, for state: AccessibilityFrameState) -> CGRect {
-        let originToView = collectionView.convert(cell.frame.origin, to: view)
-        let origin: CGPoint
-        switch state {
-        case .initial:
-            origin = CGPoint(x: originToView.x, y: originToView.y + collectionView.contentOffset.y - 35)
-        case .scroll:
-            origin = CGPoint(x: originToView.x, y: originToView.y)
-        }
-        let size = CGSize(width: view.frame.width - 20, height: cell.frame.height * height + 10)
-        return CGRect(origin: origin, size: size)
-    }
-    
     func configureAccessibilityValue(_ cell: UICollectionViewCell, current index: Int, for section: Section) {
         let label: String
         let value: String

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -11,40 +11,28 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
     
-    func latestCellRegistrationHandler(cell: GridTextCellWithAccessibility, indexPath: IndexPath, item: String) {
-        cell.text = item
-        
-        if indexPath.item == 0 {
-            cell.isAccessibilityElement = true
-            cell.accessibilityFrame = AccessibilityFrameForLatest(with: cell, height: 2, for: .initial)
-            cell.accessibilityLabel = books[currentPageOfLatest].title
-            cell.accessibilityValue = "총 \(books.count) 페이지 중 \(indexPath.item + 1) 페이지"
-            cell.accessibilityTraits = [.button, .adjustable]
-            cell.delegate = self
-        }
-    }
-    
-    func chartCellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {
-        cell.rank = indexPath.item + 1
-        cell.text = item
-        
-        if indexPath.item == 0 {
-            cell.isAccessibilityElement = true
-            cell.accessibilityFrame = AccessibilityFrameForChart(with: cell, height: 3, for: .initial)
-            cell.accessibilityLabel = "\(currentPageOfChart + 1)위, \(books[currentPageOfChart].title)"
-            cell.accessibilityValue = "총 \(books.count) 페이지 중 \(indexPath.item + 1) 페이지"
-            cell.accessibilityTraits = [.button, .adjustable]
-            cell.delegate = self
-        }
-        
-    }
-    
-    func customCellRegistrationHandler(cell: InnerCollectionListCell, indexPath: IndexPath, item: Bool) {
+    func latestCellRegistrationHandler(cell: LatestCollectionListCell, indexPath: IndexPath, item: Item) {
         cell.delegate = self
         cell.isAccessibilityElement = true
         cell.accessibilityTraits = [.button, .adjustable]
-        cell.accessibilityLabel = "\(currentPageOfCustom + 1)위, \(books[currentPageOfCustom].title)"
-        cell.accessibilityValue = "총 \(books.count) 페이지 중 \(currentPageOfCustom + 1) 페이지"
+        cell.accessibilityLabel = books[cell.currentPage].title
+        cell.accessibilityValue = "총 \(books.count) 페이지 중 \(cell.currentPage + 1) 페이지"
+    }
+    
+    func chartCellRegistrationHandler(cell: ChartCollectionListCell, indexPath: IndexPath, item: Item) {
+        cell.delegate = self
+        cell.isAccessibilityElement = true
+        cell.accessibilityTraits = [.button, .adjustable]
+        cell.accessibilityLabel = "\(cell.currentPage + 1)위, \(books[cell.currentPage].title)"
+        cell.accessibilityValue = "총 \(books.count) 페이지 중 \(cell.currentPage + 1) 페이지"
+    }
+    
+    func todayCellRegistrationHandler(cell: TodayCollectionListCell, indexPath: IndexPath, item: Item) {
+        cell.delegate = self
+        cell.isAccessibilityElement = true
+        cell.accessibilityTraits = [.button, .adjustable]
+        cell.accessibilityLabel = "\(cell.currentPage + 1)위, \(books[cell.currentPage].title)"
+        cell.accessibilityValue = "총 \(books.count) 페이지 중 \(cell.currentPage + 1) 페이지"
     }
     
     func supplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
@@ -59,14 +47,11 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     }
     
     func updateSnapshot() {
-        let latestItems = books.map{ Item(latest: $0.title) }
-        let chartItems = books.map{ Item(chart: $0.title) }
-        
         snapshot = Snapshot()
         snapshot.appendSections([.latest, .chart, .custom])
-        snapshot.appendItems(latestItems, toSection: .latest)
-        snapshot.appendItems(chartItems, toSection: .chart)
-        snapshot.appendItems([Item(custom: true)], toSection: .custom)
+        snapshot.appendItems([.latest], toSection: .latest)
+        snapshot.appendItems([.chart], toSection: .chart)
+        snapshot.appendItems([.custom], toSection: .custom)
         dataSource.apply(snapshot)
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -48,10 +48,10 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     
     func updateSnapshot() {
         snapshot = Snapshot()
-        snapshot.appendSections([.latest, .chart, .custom])
+        snapshot.appendSections([.latest, .chart, .today])
         snapshot.appendItems([.latest], toSection: .latest)
         snapshot.appendItems([.chart], toSection: .chart)
-        snapshot.appendItems([.custom], toSection: .custom)
+        snapshot.appendItems([.today], toSection: .today)
         dataSource.apply(snapshot)
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
@@ -15,7 +15,7 @@ extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAcce
             configureAccessibilityValue(cell, current: cell.currentPage, for: .latest)
             
             if cell.currentPage != 0, cell.currentPage % 4 == 0 {
-                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .left, animated: true)
+                cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .left, animated: true)
             }
         } else if let cell = view as? ChartCollectionListCell {
             guard cell.currentPage < (books.count - 1) else { return }
@@ -23,12 +23,12 @@ extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAcce
             configureAccessibilityValue(cell, current: cell.currentPage, for: .chart)
             
             if cell.currentPage != 0, cell.currentPage % 3 == 0 {
-                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 1), at: .left, animated: true)
+                cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .left, animated: true)
             }
         } else if let cell = view as? TodayCollectionListCell {
             guard cell.currentPage < (cell.books.count - 1) else { return }
             cell.currentPage += 1
-            configureAccessibilityValue(cell, current: cell.currentPage, for: .custom)
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .today)
             
             if cell.currentPage != 0, cell.currentPage % 2 == 0 {
                 cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .left, animated: true)
@@ -43,7 +43,7 @@ extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAcce
             configureAccessibilityValue(cell, current: cell.currentPage, for: .latest)
             
             if cell.currentPage % 4 == 3 {
-                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .right, animated: true)
+                cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .right, animated: true)
             }
         } else if let cell = view as? ChartCollectionListCell {
             guard cell.currentPage > 0 else { return }
@@ -51,12 +51,12 @@ extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAcce
             configureAccessibilityValue(cell, current: cell.currentPage, for: .chart)
             
             if cell.currentPage % 3 == 2 {
-                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 1), at: .right, animated: true)
+                cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .right, animated: true)
             }
         } else if let cell = view as? TodayCollectionListCell {
             guard cell.currentPage > 0 else { return }
             cell.currentPage -= 1
-            configureAccessibilityValue(cell, current: cell.currentPage, for: .custom)
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .today)
             
             if cell.currentPage % 2 == 1 {
                 cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .right, animated: true)

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
@@ -7,68 +7,59 @@
 
 import UIKit
 
-extension MelonChartNavigationViewControllerWithAccessibility: UIScrollViewDelegate, UICollectionViewDelegate {
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard let cellForLatest = collectionView.cellForItem(at: IndexPath(item: 0, section: 0)),
-              let cellForChart = collectionView.cellForItem(at: IndexPath(item: 0, section: 1)) else { return }
-        cellForLatest.accessibilityFrame = AccessibilityFrameForLatest(with: cellForLatest, height: 2, for: .scroll)
-        cellForChart.accessibilityFrame = AccessibilityFrameForChart(with: cellForChart, height: 3, for: .scroll)
-    }
-}
-
 extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAccessibility {
     func adjustableIncrement(_ view: AnyObject) {
-        if view is GridTextCellWithAccessibility {
-            guard currentPageOfLatest < (books.count - 1) else { return }
-            currentPageOfLatest += 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest, for: .latest)
+        if let cell = view as? LatestCollectionListCell {
+            guard cell.currentPage < (books.count - 1) else { return }
+            cell.currentPage += 1
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .latest)
             
-            if currentPageOfLatest != 0, currentPageOfLatest % 4 == 0 {
-                collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .left, animated: true)
+            if cell.currentPage != 0, cell.currentPage % 4 == 0 {
+                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .left, animated: true)
             }
-        } else if view is BorderedListCell {
-            guard currentPageOfChart < (books.count - 1) else { return }
-            currentPageOfChart += 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart, for: .chart)
+        } else if let cell = view as? ChartCollectionListCell {
+            guard cell.currentPage < (books.count - 1) else { return }
+            cell.currentPage += 1
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .chart)
             
-            if currentPageOfChart != 0, currentPageOfChart % 3 == 0 {
-                collectionView.scrollToItem(at: IndexPath(item: currentPageOfChart, section: 1), at: .left, animated: true)
+            if cell.currentPage != 0, cell.currentPage % 3 == 0 {
+                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 1), at: .left, animated: true)
             }
-        } else if let cell = view as? InnerCollectionListCell {
-            guard currentPageOfCustom < (cell.books.count - 1) else { return }
-            currentPageOfCustom += 1
-            configureAccessibilityValue(cell, current: currentPageOfCustom, for: .custom)
+        } else if let cell = view as? TodayCollectionListCell {
+            guard cell.currentPage < (cell.books.count - 1) else { return }
+            cell.currentPage += 1
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .custom)
             
-            if currentPageOfCustom != 0, currentPageOfCustom % 2 == 0 {
-                cell.collectionView.scrollToItem(at: IndexPath(item: currentPageOfCustom, section: 0), at: .left, animated: true)
+            if cell.currentPage != 0, cell.currentPage % 2 == 0 {
+                cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .left, animated: true)
             }
         }
     }
     
     func adjustableDecrement(_ view: AnyObject) {
-        if view is GridTextCellWithAccessibility {
-            guard currentPageOfLatest > 0 else { return }
-            currentPageOfLatest -= 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest, for: .latest)
+        if let cell = view as? LatestCollectionListCell {
+            guard cell.currentPage > 0 else { return }
+            cell.currentPage -= 1
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .latest)
             
-            if currentPageOfLatest % 4 == 3 {
-                collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .right, animated: true)
+            if cell.currentPage % 4 == 3 {
+                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .right, animated: true)
             }
-        } else if view is BorderedListCell {
-            guard currentPageOfChart > 0 else { return }
-            currentPageOfChart -= 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart, for: .chart)
+        } else if let cell = view as? ChartCollectionListCell {
+            guard cell.currentPage > 0 else { return }
+            cell.currentPage -= 1
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .chart)
             
-            if currentPageOfChart % 3 == 2 {
-                collectionView.scrollToItem(at: IndexPath(item: currentPageOfChart, section: 1), at: .right, animated: true)
+            if cell.currentPage % 3 == 2 {
+                collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 1), at: .right, animated: true)
             }
-        } else if let cell = view as? InnerCollectionListCell {
-            guard currentPageOfCustom > 0 else { return }
-            currentPageOfCustom -= 1
-            configureAccessibilityValue(cell, current: currentPageOfCustom, for: .custom)
+        } else if let cell = view as? TodayCollectionListCell {
+            guard cell.currentPage > 0 else { return }
+            cell.currentPage -= 1
+            configureAccessibilityValue(cell, current: cell.currentPage, for: .custom)
             
-            if currentPageOfCustom % 2 == 1 {
-                cell.collectionView.scrollToItem(at: IndexPath(item: currentPageOfCustom, section: 0), at: .right, animated: true)
+            if cell.currentPage % 2 == 1 {
+                cell.collectionView.scrollToItem(at: IndexPath(item: cell.currentPage, section: 0), at: .right, animated: true)
             }
         } 
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
@@ -26,7 +26,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
             return sectionForLatest()
         case .chart:
             return sectionForChart()
-        case .custom:
+        case .today:
             return sectionForCustom()
         }
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
@@ -32,38 +32,29 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     }
     
     func sectionForLatest() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.48))
-        let nestedGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.48), heightDimension: .fractionalHeight(1.0))
-        let containerGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.95), heightDimension: .absolute(480))
-        
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
-        let nestedGroup = NSCollectionLayoutGroup.vertical(layoutSize: nestedGroupSize, repeatingSubitem: item, count: 2)
-        nestedGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(500))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
         
-        let containerGroup = NSCollectionLayoutGroup.horizontal(layoutSize: containerGroupSize, repeatingSubitem: nestedGroup, count: 2)
-        containerGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
-        
-        let section = NSCollectionLayoutSection(group: containerGroup)
+        let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
         section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
-        section.orthogonalScrollingBehavior = .continuous
         
         return section
     }
     
     func sectionForChart() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.93), heightDimension: .fractionalHeight(0.9))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .estimated(80))
-        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 3)
-        group.interItemSpacing = .fixed(5)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(250))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
         section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
-        section.orthogonalScrollingBehavior = .groupPaging
         
         return section
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
@@ -53,7 +53,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     }
     
     func sectionForChart() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalHeight(0.9))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.93), heightDimension: .fractionalHeight(0.9))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .estimated(80))
@@ -69,7 +69,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     }
     
     func sectionForCustom() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(200))

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
@@ -10,22 +10,22 @@ import Foundation
 //MARK: Types for DataSource
 extension MelonChartNavigationViewControllerWithAccessibility {
     enum Section: Int {
-        case latest, chart, custom
+        case latest, chart, today
         
         var title: String {
             switch self {
             case .latest:
-                return "Latest"
+                return "최신 음악"
             case .chart:
-                return "Chart"
-            case .custom:
-                return "Custom"
+                return "음악 차트"
+            case .today:
+                return "오늘의 음악"
             }
         }
     }
     
     enum Item: Int {
-        case latest, chart, custom
+        case latest, chart, today
     }
     
     enum Supplementary: String {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
@@ -24,29 +24,8 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         }
     }
     
-    struct Item: Hashable {
-        let latest: String?
-        let chart: String?
-        let custom: Bool?
-        
-        init(latest: String?, chart: String?, custom: Bool?) {
-            self.latest = latest
-            self.chart = chart
-            self.custom = custom
-        }
-        
-        init(latest: String) {
-            self.init(latest: latest, chart: nil, custom: nil)
-        }
-        
-        init(chart: String) {
-            self.init(latest: nil, chart: chart, custom: nil)
-        }
-        
-        init(custom: Bool) {
-            self.init(latest: nil, chart: nil, custom: custom)
-        }
-        
+    enum Item: Int {
+        case latest, chart, custom
     }
     
     enum Supplementary: String {
@@ -55,9 +34,5 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         var name: String {
             self.rawValue
         }
-    }
-    
-    enum AccessibilityFrameState {
-        case initial, scroll
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -13,9 +13,6 @@ final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewCont
     var snapshot: Snapshot!
     var accessibilityelements: [Any] = []
     var books = Book.samples
-    var currentPageOfLatest = 0
-    var currentPageOfChart = 0
-    var currentPageOfCustom = 0
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     
@@ -33,7 +30,6 @@ final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewCont
 private extension MelonChartNavigationViewControllerWithAccessibility {
     func configureSubviews() {
         collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 20, right: -10)
-        collectionView.delegate = self
     }
     
     func configureView() {
@@ -43,7 +39,7 @@ private extension MelonChartNavigationViewControllerWithAccessibility {
     func configureDataSource() {
         let latestCellRegistration = UICollectionView.CellRegistration(handler: latestCellRegistrationHandler)
         let chartCellRegistration = UICollectionView.CellRegistration(handler: chartCellRegistrationHandler)
-        let customCellRegistration = UICollectionView.CellRegistration(handler: customCellRegistrationHandler)
+        let customCellRegistration = UICollectionView.CellRegistration(handler: todayCellRegistrationHandler)
         
         dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
             guard let section = Section(rawValue: indexPath.section) else {
@@ -51,11 +47,11 @@ private extension MelonChartNavigationViewControllerWithAccessibility {
             }
             switch section {
             case .latest:
-                return collectionView.dequeueConfiguredReusableCell(using: latestCellRegistration, for: indexPath, item: itemIdentifier.latest)
+                return collectionView.dequeueConfiguredReusableCell(using: latestCellRegistration, for: indexPath, item: itemIdentifier)
             case .chart:
-                return collectionView.dequeueConfiguredReusableCell(using: chartCellRegistration, for: indexPath, item: itemIdentifier.chart)
+                return collectionView.dequeueConfiguredReusableCell(using: chartCellRegistration, for: indexPath, item: itemIdentifier)
             case.custom:
-                return collectionView.dequeueConfiguredReusableCell(using: customCellRegistration, for: indexPath, item: itemIdentifier.custom)
+                return collectionView.dequeueConfiguredReusableCell(using: customCellRegistration, for: indexPath, item: itemIdentifier)
             }
         })
         

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -50,7 +50,7 @@ private extension MelonChartNavigationViewControllerWithAccessibility {
                 return collectionView.dequeueConfiguredReusableCell(using: latestCellRegistration, for: indexPath, item: itemIdentifier)
             case .chart:
                 return collectionView.dequeueConfiguredReusableCell(using: chartCellRegistration, for: indexPath, item: itemIdentifier)
-            case.custom:
+            case .today:
                 return collectionView.dequeueConfiguredReusableCell(using: customCellRegistration, for: indexPath, item: itemIdentifier)
             }
         })

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/TodayCollectionListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/TodayCollectionListCell.swift
@@ -1,5 +1,5 @@
 //
-//  InnerCollectionListCell.swift
+//  TodayCollectionListCell.swift
 //  DefaultComponents-Accessibility
 //
 //  Created by 임윤휘 on 10/14/24.
@@ -7,10 +7,12 @@
 
 import UIKit
 
-final class InnerCollectionListCell: UICollectionViewCell {
+final class TodayCollectionListCell: UICollectionViewCell {
     
     var dataSource: UICollectionViewDiffableDataSource<Int, String>!
     var books = Book.samples
+    var currentPage = 0
+    
     weak var delegate: AdjustableForAccessibility?
     private var currentPageOfCustom = 0
     
@@ -36,11 +38,9 @@ final class InnerCollectionListCell: UICollectionViewCell {
     }
 }
 
-private extension InnerCollectionListCell {
+private extension TodayCollectionListCell {
     
     func configureContentView() {
-        contentView.addPinnedSubview(collectionView, height: nil)
-        
         let cellRegistration = UICollectionView.CellRegistration(handler: cellRegistrationHandler)
         
         dataSource = UICollectionViewDiffableDataSource<Int, String>(collectionView: collectionView) { collectionView,indexPath,itemIdentifier in
@@ -52,6 +52,8 @@ private extension InnerCollectionListCell {
         snapshot.appendItems(books.map({$0.title}))
         dataSource.apply(snapshot)
         collectionView.dataSource = dataSource
+        
+        contentView.addPinnedSubview(collectionView, height: nil)
     }
     
     func layout() -> UICollectionViewLayout {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/BorderedListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/BorderedListCell.swift
@@ -61,10 +61,12 @@ class BorderedListCell: UICollectionViewCell, Identifiable {
 // MARK: Configuration
 private extension BorderedListCell {
     func configureSubviews() {
-        rankLabel.font = .systemFont(ofSize: 15, weight: .regular)
+        
+        rankLabel.sizeToFit()
         rankLabel.isAccessibilityElement = false
-        textLabel.font = .systemFont(ofSize: 15, weight: .thin)
+        
         textLabel.isAccessibilityElement = false
+        textLabel.textAlignment = .left
         contentView.layer.borderWidth = 1
         contentView.layer.borderColor = UIColor.black.cgColor
     }
@@ -75,16 +77,14 @@ private extension BorderedListCell {
     
     func configureConstraints() {
         let spacing: CGFloat = 5.0
-        let height = contentView.frame.width
         
         NSLayoutConstraint.activate([
             rankLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: spacing),
             rankLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
-            rankLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             
             textLabel.centerYAnchor.constraint(equalTo: rankLabel.centerYAnchor),
-            textLabel.leadingAnchor.constraint(equalTo: rankLabel.leadingAnchor, constant: 15),
-            textLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+            textLabel.leadingAnchor.constraint(equalTo: rankLabel.trailingAnchor, constant: 10),
+            textLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor)
         ])
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/BorderedListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/BorderedListCell.swift
@@ -84,7 +84,7 @@ private extension BorderedListCell {
             
             textLabel.centerYAnchor.constraint(equalTo: rankLabel.centerYAnchor),
             textLabel.leadingAnchor.constraint(equalTo: rankLabel.trailingAnchor, constant: 10),
-            textLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor)
+            textLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -10)
         ])
     }
 }


### PR DESCRIPTION
멜론 차트 탐색 초점 오류 수정 및 이외 수정 사항 반영

## 초점 오류
Compositional Layout을 사용한 Section을 구분하여 초점을 첫 번째 아이템에 향하도록 하며 accessibilityFrame을 확장시키는 방식으로 구현했지만, 임의탐색의 어려움과 아이템 전환 시 초점 누락의 오류가 발생
- 1차원 리스트를 중첩하는 custom 방식으로 전면 변경

<br>

## 이외 수정 사항
 - 기본/개선 컴포넌트 데이터가 화면 표시되는 방식이 동일하도록
 - Chart에서 아이템 내부 label이 서로 겹치는 오류 수정


<br>

<br>


| 기본 | 개선 |
| ----- | ----- |
|  <img src = "https://github.com/user-attachments/assets/131bd983-beb9-4d97-b04d-6a410b5ed228" width = 200 height = 400> |  <img src = "https://github.com/user-attachments/assets/07952f01-6135-4841-af6d-db8b21539e39" width = 200 height = 400> |

<br>






#62 


