### PR TITLE
[List] feat: 멜론 동작 추가 (상세, 재생)

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -20,11 +20,12 @@
 		144FC6F32CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */; };
 		144FC6F52CBCD87300CC75FE /* BorderedListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */; };
 		144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */; };
-		144FC6FA2CBCE8B000CC75FE /* InnerCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */; };
+		144FC6FA2CBCE8B000CC75FE /* TodayCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */; };
 		14852BE32CC1FA0D00F53857 /* NewsListViewControllerWithAccessibility+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BE22CC1FA0D00F53857 /* NewsListViewControllerWithAccessibility+DataSource.swift */; };
 		14852BE52CC1FA4800F53857 /* NewsListViewControllerWithAccessibility+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BE42CC1FA4800F53857 /* NewsListViewControllerWithAccessibility+Delegate.swift */; };
 		14852BE72CC20B4300F53857 /* ButtonTraitsTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BE62CC20B4300F53857 /* ButtonTraitsTableCell.swift */; };
-		144FC6FA2CBCE8B000CC75FE /* TodayCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */; };
+		14852BEB2CC227DE00F53857 /* MelonListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEA2CC227DE00F53857 /* MelonListCell.swift */; };
+		14852BED2CC22CD500F53857 /* MusicGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEC2CC22CD500F53857 /* MusicGroupView.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -118,11 +119,12 @@
 		144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTextCellWithAccessibility.swift; sourceTree = "<group>"; };
 		144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderedListCell.swift; sourceTree = "<group>"; };
 		144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustableForAccessibility.swift; sourceTree = "<group>"; };
-		144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InnerCollectionListCell.swift; sourceTree = "<group>"; };
+		144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCollectionListCell.swift; sourceTree = "<group>"; };
 		14852BE22CC1FA0D00F53857 /* NewsListViewControllerWithAccessibility+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NewsListViewControllerWithAccessibility+DataSource.swift"; sourceTree = "<group>"; };
 		14852BE42CC1FA4800F53857 /* NewsListViewControllerWithAccessibility+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NewsListViewControllerWithAccessibility+Delegate.swift"; sourceTree = "<group>"; };
 		14852BE62CC20B4300F53857 /* ButtonTraitsTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTraitsTableCell.swift; sourceTree = "<group>"; };
-		144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCollectionListCell.swift; sourceTree = "<group>"; };
+		14852BEA2CC227DE00F53857 /* MelonListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelonListCell.swift; sourceTree = "<group>"; };
+		14852BEC2CC22CD500F53857 /* MusicGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicGroupView.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -223,6 +225,8 @@
 				144564272CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift */,
 				144564232CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift */,
 				144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */,
+				14852BEA2CC227DE00F53857 /* MelonListCell.swift */,
+				14852BEC2CC22CD500F53857 /* MusicGroupView.swift */,
 			);
 			path = MelonChartNavigationViewController;
 			sourceTree = "<group>";
@@ -690,6 +694,7 @@
 				1445642C2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift in Sources */,
 				4EC52B002CA14976007E07D6 /* TableViewController+Delegate.swift in Sources */,
 				4EC51C972C91226300385BD0 /* OutlineViewController.swift in Sources */,
+				14852BED2CC22CD500F53857 /* MusicGroupView.swift in Sources */,
 				4EB123002CB793B100D771D3 /* ButtonSupplementaryView.swift in Sources */,
 				14852BE32CC1FA0D00F53857 /* NewsListViewControllerWithAccessibility+DataSource.swift in Sources */,
 				4EC52AFE2CA145C0007E07D6 /* TableViewController+DataSource.swift in Sources */,
@@ -715,6 +720,7 @@
 				4E1BC4F72CAF7244001A29D5 /* SearchViewController+Updating.swift in Sources */,
 				144FC6FA2CBCE8B000CC75FE /* TodayCollectionListCell.swift in Sources */,
 				4EB122FA2CB7694300D771D3 /* NewsListCell.swift in Sources */,
+				14852BEB2CC227DE00F53857 /* MelonListCell.swift in Sources */,
 				4E285DBF2C8FE947007F286C /* ButtonAndSliderViewController+Action.swift in Sources */,
 				14F7FC422CB2C8DC00F3FA61 /* SearchViewControllerWithAccessibility+Delegate.swift in Sources */,
 				4EC51C9F2C912AD800385BD0 /* OutLineViewController+Delegate.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -229,9 +229,9 @@
 				144564272CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift */,
 				144564232CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift */,
 				144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */,
+				14852BEE2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift */,
 				14852BEA2CC227DE00F53857 /* MelonListCell.swift */,
 				14852BEC2CC22CD500F53857 /* MusicGroupView.swift */,
-				14852BEE2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift */,
 			);
 			path = MelonChartNavigationViewController;
 			sourceTree = "<group>";

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		14852BEB2CC227DE00F53857 /* MelonListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEA2CC227DE00F53857 /* MelonListCell.swift */; };
 		14852BED2CC22CD500F53857 /* MusicGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEC2CC22CD500F53857 /* MusicGroupView.swift */; };
 		14852BEF2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEE2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift */; };
+		14852BF12CC2384F00F53857 /* MelonListCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BF02CC2384F00F53857 /* MelonListCellWithAccessibility.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -127,6 +128,7 @@
 		14852BEA2CC227DE00F53857 /* MelonListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelonListCell.swift; sourceTree = "<group>"; };
 		14852BEC2CC22CD500F53857 /* MusicGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicGroupView.swift; sourceTree = "<group>"; };
 		14852BEE2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+Action.swift"; sourceTree = "<group>"; };
+		14852BF02CC2384F00F53857 /* MelonListCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelonListCellWithAccessibility.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				144FC6F92CBCE8B000CC75FE /* TodayCollectionListCell.swift */,
 				4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */,
 				4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */,
+				14852BF02CC2384F00F53857 /* MelonListCellWithAccessibility.swift */,
 			);
 			path = MelonChartNavigationViewControllerWithAccessibility;
 			sourceTree = "<group>";
@@ -701,6 +704,7 @@
 				14852BED2CC22CD500F53857 /* MusicGroupView.swift in Sources */,
 				4EB123002CB793B100D771D3 /* ButtonSupplementaryView.swift in Sources */,
 				14852BE32CC1FA0D00F53857 /* NewsListViewControllerWithAccessibility+DataSource.swift in Sources */,
+				14852BF12CC2384F00F53857 /* MelonListCellWithAccessibility.swift in Sources */,
 				4EC52AFE2CA145C0007E07D6 /* TableViewController+DataSource.swift in Sources */,
 				1445642A2CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift in Sources */,
 				144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		14852BE72CC20B4300F53857 /* ButtonTraitsTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BE62CC20B4300F53857 /* ButtonTraitsTableCell.swift */; };
 		14852BEB2CC227DE00F53857 /* MelonListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEA2CC227DE00F53857 /* MelonListCell.swift */; };
 		14852BED2CC22CD500F53857 /* MusicGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEC2CC22CD500F53857 /* MusicGroupView.swift */; };
+		14852BEF2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14852BEE2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -125,6 +126,7 @@
 		14852BE62CC20B4300F53857 /* ButtonTraitsTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTraitsTableCell.swift; sourceTree = "<group>"; };
 		14852BEA2CC227DE00F53857 /* MelonListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelonListCell.swift; sourceTree = "<group>"; };
 		14852BEC2CC22CD500F53857 /* MusicGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicGroupView.swift; sourceTree = "<group>"; };
+		14852BEE2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+Action.swift"; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */,
 				14852BEA2CC227DE00F53857 /* MelonListCell.swift */,
 				14852BEC2CC22CD500F53857 /* MusicGroupView.swift */,
+				14852BEE2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift */,
 			);
 			path = MelonChartNavigationViewController;
 			sourceTree = "<group>";
@@ -674,6 +677,7 @@
 			files = (
 				144FC6F52CBCD87300CC75FE /* BorderedListCell.swift in Sources */,
 				144564282CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift in Sources */,
+				14852BEF2CC232AF00F53857 /* MelonChartNavigationViewController+Action.swift in Sources */,
 				4EEEE6132CC0D9B500FCF08B /* ChartCollectionListCell.swift in Sources */,
 				4E0AB03F2C9BAB9700B8A89C /* Detail.swift in Sources */,
 				4E855F542CACE15C008CDB3B /* DefaultCollectionViewController.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Action.swift
@@ -1,0 +1,20 @@
+//
+//  MelonChartNavigationViewController+Action.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/18/24.
+//
+
+import UIKit
+
+extension MelonChartNavigationViewController {
+    @objc func didTapPlayButton(_ sender: UIButton) {
+        let title = books[sender.tag].title
+        let alert = UIAlertController(title: "음악 재생", message: "<\(title)>을 재생하시겠습니까?", preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let okAction = UIAlertAction(title: "확인", style: .default)
+        [ cancelAction, okAction ]
+            .forEach{ alert.addAction($0) }
+        self.present(alert, animated: true)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Action.swift
@@ -17,4 +17,9 @@ extension MelonChartNavigationViewController {
             .forEach{ alert.addAction($0) }
         self.present(alert, animated: true)
     }
+    
+    @objc func didTapMusicGroup() {
+        let vc = TableViewController(isAccessible: false)
+        navigationController?.pushViewController(vc, animated: true)
+    }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
@@ -11,7 +11,7 @@ extension MelonChartNavigationViewController {
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
     
-    func latestCellRegistrationHandler(cell: GridTextCell, indexPath: IndexPath, item: String) {
+    func latestCellRegistrationHandler(cell: MelonListCell, indexPath: IndexPath, item: String) {
         cell.text = item
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
@@ -13,6 +13,12 @@ extension MelonChartNavigationViewController {
     
     func latestCellRegistrationHandler(cell: MelonListCell, indexPath: IndexPath, item: String) {
         cell.text = item
+        cell.musicGroupView.action = {[self] in
+            let vc = TableViewController(isAccessible: false)
+            self.present(vc, animated: true)
+        }
+        cell.playButton.tag = indexPath.item
+        cell.playButton.addTarget(self, action: #selector(didTapPlayButton(_:)), for: .touchUpInside)
     }
     
     func chartCellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
@@ -13,10 +13,7 @@ extension MelonChartNavigationViewController {
     
     func latestCellRegistrationHandler(cell: MelonListCell, indexPath: IndexPath, item: String) {
         cell.text = item
-        cell.musicGroupView.action = {[self] in
-            let vc = TableViewController(isAccessible: false)
-            self.present(vc, animated: true)
-        }
+        cell.musicGroupView.addTarget(self, action: #selector(didTapMusicGroup), for: .touchUpInside)
         cell.playButton.tag = indexPath.item
         cell.playButton.addTarget(self, action: #selector(didTapPlayButton(_:)), for: .touchUpInside)
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonListCell.swift
@@ -1,0 +1,83 @@
+//
+//  MelonListCell.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/18/24.
+//
+
+import UIKit
+
+final class MelonListCell: UICollectionViewCell {
+    
+    var thumbnailImage: UIImage? {
+        didSet {
+            musicGroupView.thumbnailImage = thumbnailImage
+        }
+    }
+    var text: String! {
+        didSet {
+            musicGroupView.text = text
+        }
+    }
+    var secondaryText: String? {
+        didSet {
+            musicGroupView.secondaryText = secondaryText
+        }
+    }
+    
+    private lazy var musicGroupView = MusicGroupView(frame: frame)
+    private lazy var playButton = UIButton()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureSubviews()
+        configureContentView()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        musicGroupView.imageView.image = nil
+        musicGroupView.textLabel.text = nil
+        musicGroupView.secondaryTextLabel.text = nil
+    }
+    
+    @objc func didTapPlayButton() {
+        print("Present a Music Player")
+    }
+}
+
+// MARK: Configuration
+private extension MelonListCell {
+    func configureSubviews() {
+        
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "play.fill")
+        config.baseForegroundColor = .white
+        playButton.configuration = config
+        playButton.addTarget(self, action: #selector(didTapPlayButton), for: .touchUpInside)
+    }
+    
+    func configureContentView() {
+        
+    }
+    
+    func configureConstraints() {
+        contentView.addPinnedSubview(musicGroupView, height: nil)
+        contentView.addSubviews([playButton])
+        
+        let spacing: CGFloat = 5.0
+        let height = contentView.frame.width
+        let horizontalInset: CGFloat = 5.0
+        
+        NSLayoutConstraint.activate([
+            playButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: horizontalInset),
+            playButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -horizontalInset)
+        ])
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonListCell.swift
@@ -66,8 +66,6 @@ private extension MelonListCell {
         contentView.addPinnedSubview(musicGroupView, height: nil)
         contentView.addSubviews([playButton])
         
-        let spacing: CGFloat = 5.0
-        let height = contentView.frame.width
         let horizontalInset: CGFloat = 5.0
         
         NSLayoutConstraint.activate([

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonListCell.swift
@@ -25,8 +25,8 @@ final class MelonListCell: UICollectionViewCell {
         }
     }
     
-    private lazy var musicGroupView = MusicGroupView(frame: frame)
-    private lazy var playButton = UIButton()
+    lazy var musicGroupView = MusicGroupView(frame: frame)
+    lazy var playButton = UIButton()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,10 +46,6 @@ final class MelonListCell: UICollectionViewCell {
         musicGroupView.textLabel.text = nil
         musicGroupView.secondaryTextLabel.text = nil
     }
-    
-    @objc func didTapPlayButton() {
-        print("Present a Music Player")
-    }
 }
 
 // MARK: Configuration
@@ -60,7 +56,6 @@ private extension MelonListCell {
         config.image = UIImage(systemName: "play.fill")
         config.baseForegroundColor = .white
         playButton.configuration = config
-        playButton.addTarget(self, action: #selector(didTapPlayButton), for: .touchUpInside)
     }
     
     func configureContentView() {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MusicGroupView.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MusicGroupView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class MusicGroupView: UIView {
+final class MusicGroupView: UIControl {
     
     var thumbnailImage: UIImage? {
         didSet {
@@ -25,8 +25,6 @@ final class MusicGroupView: UIView {
         }
     }
     
-    var action: (() -> Void)?
-    
     lazy var imageView = UIImageView()
     lazy var textLabel = UILabel()
     lazy var secondaryTextLabel = UILabel()
@@ -42,12 +40,6 @@ final class MusicGroupView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        super.touchesBegan(touches, with: event)
-        action?()
-        
     }
 }
 

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MusicGroupView.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MusicGroupView.swift
@@ -1,0 +1,95 @@
+//
+//  MusicGroupView.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/18/24.
+//
+
+import UIKit
+
+final class MusicGroupView: UIView {
+    
+    var thumbnailImage: UIImage? {
+        didSet {
+            imageView.image = thumbnailImage
+        }
+    }
+    var text: String! {
+        didSet {
+            textLabel.text = text
+        }
+    }
+    var secondaryText: String? {
+        didSet {
+            secondaryTextLabel.text = secondaryText
+        }
+    }
+    
+    lazy var imageView = UIImageView()
+    lazy var textLabel = UILabel()
+    lazy var secondaryTextLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureSubviews()
+        setPreferredFontyStyle()
+        configureContentView()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        print("Present a Music Detail")
+    }
+}
+
+// MARK: Configuration
+private extension MusicGroupView {
+    func configureSubviews() {
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .darkGray
+        
+        textLabel.font = .systemFont(ofSize: 15, weight: .regular)
+        secondaryTextLabel.font = .systemFont(ofSize: 15, weight: .thin)
+    }
+    
+    func configureContentView() {
+        isUserInteractionEnabled = true
+    }
+    
+    func configureConstraints() {
+        addSubviews([imageView, textLabel, secondaryTextLabel])
+        
+        let spacing: CGFloat = 5.0
+        let height = frame.width
+        
+        NSLayoutConstraint.activate([
+            imageView.heightAnchor.constraint(equalToConstant: height),
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: topAnchor),
+            
+            textLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: spacing),
+            textLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            
+            secondaryTextLabel.topAnchor.constraint(equalTo: textLabel.bottomAnchor),
+            secondaryTextLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            secondaryTextLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            secondaryTextLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}
+
+extension MusicGroupView: DynamicTypeable {
+    func setPreferredFontyStyle() {
+        textLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        secondaryTextLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MusicGroupView.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MusicGroupView.swift
@@ -25,6 +25,8 @@ final class MusicGroupView: UIView {
         }
     }
     
+    var action: (() -> Void)?
+    
     lazy var imageView = UIImageView()
     lazy var textLabel = UILabel()
     lazy var secondaryTextLabel = UILabel()
@@ -44,7 +46,8 @@ final class MusicGroupView: UIView {
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
-        print("Present a Music Detail")
+        action?()
+        
     }
 }
 

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/LatestCollectionListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/LatestCollectionListCell.swift
@@ -12,6 +12,7 @@ final class LatestCollectionListCell: UICollectionViewCell {
     var dataSource: UICollectionViewDiffableDataSource<Int, String>!
     var books = Book.samples
     var currentPage = 0
+    var presenting: UIViewController?
     
     weak var delegate: AdjustableForAccessibility?
     private var currentPageOfCustom = 0
@@ -35,6 +36,17 @@ final class LatestCollectionListCell: UICollectionViewCell {
     
     override func accessibilityDecrement() {
         delegate?.adjustableDecrement(self)
+    }
+    
+    
+    @objc func didTapPlayButton(_ sender: UIButton) {
+        let title = books[sender.tag].title
+        let alert = UIAlertController(title: "음악 재생", message: "<\(title)>을 재생하시겠습니까?", preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let okAction = UIAlertAction(title: "확인", style: .default)
+        [ cancelAction, okAction ]
+            .forEach{ alert.addAction($0) }
+        presenting?.present(alert, animated: true)
     }
 }
 
@@ -76,8 +88,14 @@ private extension LatestCollectionListCell {
         return UICollectionViewCompositionalLayout(section: section)
     }
     
-    func cellRegistrationHandler(cell: GridTextCellWithAccessibility, indexPath: IndexPath, item: String) {
+    func cellRegistrationHandler(cell: MelonListCellWithAccessibility, indexPath: IndexPath, item: String) {
         cell.text = item
+        cell.musicGroupView.action = {[presenting] in
+            let vc = TableViewController(isAccessible: false)
+            presenting?.present(vc, animated: true)
+        }
+        cell.playButton.tag = indexPath.item
+        cell.playButton.addTarget(self, action: #selector(didTapPlayButton(_:)), for: .touchUpInside)
     }
     
     func configureAccessibilityValue(current index: Int) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -17,6 +17,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         cell.accessibilityTraits = [.button, .adjustable]
         cell.accessibilityLabel = books[cell.currentPage].title
         cell.accessibilityValue = "총 \(books.count) 페이지 중 \(cell.currentPage + 1) 페이지"
+        cell.presenting = self
     }
     
     func chartCellRegistrationHandler(cell: ChartCollectionListCell, indexPath: IndexPath, item: Item) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonListCellWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonListCellWithAccessibility.swift
@@ -76,8 +76,6 @@ private extension MelonListCellWithAccessibility {
         contentView.addPinnedSubview(musicGroupView, height: nil)
         contentView.addSubviews([playButton])
         
-        let spacing: CGFloat = 5.0
-        let height = contentView.frame.width
         let horizontalInset: CGFloat = 5.0
         
         NSLayoutConstraint.activate([

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonListCellWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonListCellWithAccessibility.swift
@@ -1,0 +1,88 @@
+//
+//  MelonListCellWithAccessibility.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/18/24.
+//
+
+import UIKit
+
+final class MelonListCellWithAccessibility: UICollectionViewCell {
+    
+    var thumbnailImage: UIImage? {
+        didSet {
+            musicGroupView.thumbnailImage = thumbnailImage
+        }
+    }
+    var text: String! {
+        didSet {
+            musicGroupView.text = text
+        }
+    }
+    var secondaryText: String? {
+        didSet {
+            musicGroupView.secondaryText = secondaryText
+        }
+    }
+    weak var delegate: AdjustableForAccessibility?
+    
+    lazy var musicGroupView = MusicGroupView(frame: frame)
+    lazy var playButton = UIButton()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureSubviews()
+        configureContentView()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        musicGroupView.imageView.image = nil
+        musicGroupView.textLabel.text = nil
+        musicGroupView.secondaryTextLabel.text = nil
+    }
+    
+    override func accessibilityIncrement() {
+        delegate?.adjustableIncrement(self)
+        
+    }
+    
+    override func accessibilityDecrement() {
+        delegate?.adjustableDecrement(self)
+    }
+}
+
+// MARK: Configuration
+private extension MelonListCellWithAccessibility {
+    func configureSubviews() {
+        
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "play.fill")
+        config.baseForegroundColor = .white
+        playButton.configuration = config
+    }
+    
+    func configureContentView() {
+        
+    }
+    
+    func configureConstraints() {
+        contentView.addPinnedSubview(musicGroupView, height: nil)
+        contentView.addSubviews([playButton])
+        
+        let spacing: CGFloat = 5.0
+        let height = contentView.frame.width
+        let horizontalInset: CGFloat = 5.0
+        
+        NSLayoutConstraint.activate([
+            playButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: horizontalInset),
+            playButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -horizontalInset)
+        ])
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/NewsListViewController/NewsListViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/NewsListViewController/NewsListViewController.swift
@@ -54,7 +54,7 @@ private extension NewsListViewController {
 extension NewsListViewController: ButtonSupplementaryViewDelegate {
     func buttonSupplementaryView(didTapButton button: UIButton) {
         if pagable.total == News.samples.count {
-            var alert = UIAlertController(title: "마지막 페이지입니다", message: "모든 페이지를 확인하셨습니다.", preferredStyle: .alert)
+            let alert = UIAlertController(title: "마지막 페이지입니다", message: "모든 페이지를 확인하셨습니다.", preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "확인", style: .default))
             self.present(alert, animated: true)
             return


### PR DESCRIPTION
### 재생

- 재생버튼 삽입
- 동작
    - 기본: 재생 버튼 클릭 시 "음악 재생" Alert present
    - 개선: '음악 재생' 동작 추가


### 상세
- [x] 동작
    - 기본: 아이템 클릭 시 버튼 클릭 시 TableVC present
    - 개선: '상세 보기' 동작 추가



<br>

<br>

### UI 변화
| melon | 음악 재생 | 상세보기 |
| ----- | ----- | ----- |
|  <img src = "https://github.com/user-attachments/assets/55e44f80-feb5-4e8e-bde4-f392a225f863" width = 200 height = 400> |  <img src = "https://github.com/user-attachments/assets/c58df626-7919-41c3-b0ae-2bce3d09fcff" width = 200 height = 400> |   <img src = "https://github.com/user-attachments/assets/acf2f97c-1f77-4f85-b12c-560849151ec4" width = 200 height = 400> |


<br>







#67
