### PR TITLE
[ Issue1 ] ui/feat: 임의 탐색 초점 크기

### DIFF
--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -330,6 +331,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		143B104C2CC7F590000E5A4C /* TaxiCallView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143B104B2CC7F590000E5A4C /* TaxiCallView2.swift */; };
 		4E30476F2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E30476E2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift */; };
 		4E3047712CC5E4810044ACF2 /* TaxiCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */; };
 		4E3047732CC5E4820044ACF2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E3047722CC5E4820044ACF2 /* Assets.xcassets */; };
@@ -15,6 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		143B104B2CC7F590000E5A4C /* TaxiCallView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiCallView2.swift; sourceTree = "<group>"; };
 		4E30476B2CC5E4810044ACF2 /* IssueCard-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "IssueCard-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E30476E2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCard_SwiftUIApp.swift; sourceTree = "<group>"; };
 		4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiCallView.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 			children = (
 				4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */,
 				4E30477F2CC62F670044ACF2 /* MapView.swift */,
+				143B104B2CC7F590000E5A4C /* TaxiCallView2.swift */,
 			);
 			path = Isuue1;
 			sourceTree = "<group>";
@@ -150,6 +153,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4E3047712CC5E4810044ACF2 /* TaxiCallView.swift in Sources */,
+				143B104C2CC7F590000E5A4C /* TaxiCallView2.swift in Sources */,
 				4E3047802CC62F670044ACF2 /* MapView.swift in Sources */,
 				4E30476F2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift in Sources */,
 			);

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
@@ -115,10 +115,11 @@
 			};
 			buildConfigurationList = 4E3047662CC5E4810044ACF2 /* Build configuration list for PBXProject "IssueCard-SwiftUI" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				ko,
 				Base,
 			);
 			mainGroup = 4E3047622CC5E4810044ACF2;
@@ -290,8 +291,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -299,9 +300,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tistory.88yhtserof.IssueCard-SwiftUI";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -319,8 +324,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -328,9 +333,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tistory.88yhtserof.IssueCard-SwiftUI";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
@@ -1,0 +1,357 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4E30476F2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E30476E2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift */; };
+		4E3047712CC5E4810044ACF2 /* TaxiCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */; };
+		4E3047732CC5E4820044ACF2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E3047722CC5E4820044ACF2 /* Assets.xcassets */; };
+		4E3047762CC5E4820044ACF2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E3047752CC5E4820044ACF2 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4E30476B2CC5E4810044ACF2 /* IssueCard-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "IssueCard-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4E30476E2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCard_SwiftUIApp.swift; sourceTree = "<group>"; };
+		4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiCallView.swift; sourceTree = "<group>"; };
+		4E3047722CC5E4820044ACF2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4E3047752CC5E4820044ACF2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4E3047682CC5E4810044ACF2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4E3047622CC5E4810044ACF2 = {
+			isa = PBXGroup;
+			children = (
+				4E30476D2CC5E4810044ACF2 /* IssueCard-SwiftUI */,
+				4E30476C2CC5E4810044ACF2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		4E30476C2CC5E4810044ACF2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4E30476B2CC5E4810044ACF2 /* IssueCard-SwiftUI.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4E30476D2CC5E4810044ACF2 /* IssueCard-SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				4E30477C2CC5F25D0044ACF2 /* Isuue1 */,
+				4E30476E2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift */,
+				4E3047722CC5E4820044ACF2 /* Assets.xcassets */,
+				4E3047742CC5E4820044ACF2 /* Preview Content */,
+			);
+			path = "IssueCard-SwiftUI";
+			sourceTree = "<group>";
+		};
+		4E3047742CC5E4820044ACF2 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				4E3047752CC5E4820044ACF2 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		4E30477C2CC5F25D0044ACF2 /* Isuue1 */ = {
+			isa = PBXGroup;
+			children = (
+				4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */,
+			);
+			path = Isuue1;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4E30476A2CC5E4810044ACF2 /* IssueCard-SwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E3047792CC5E4820044ACF2 /* Build configuration list for PBXNativeTarget "IssueCard-SwiftUI" */;
+			buildPhases = (
+				4E3047672CC5E4810044ACF2 /* Sources */,
+				4E3047682CC5E4810044ACF2 /* Frameworks */,
+				4E3047692CC5E4810044ACF2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "IssueCard-SwiftUI";
+			productName = "IssueCard-SwiftUI";
+			productReference = 4E30476B2CC5E4810044ACF2 /* IssueCard-SwiftUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4E3047632CC5E4810044ACF2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					4E30476A2CC5E4810044ACF2 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = 4E3047662CC5E4810044ACF2 /* Build configuration list for PBXProject "IssueCard-SwiftUI" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 4E3047622CC5E4810044ACF2;
+			productRefGroup = 4E30476C2CC5E4810044ACF2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4E30476A2CC5E4810044ACF2 /* IssueCard-SwiftUI */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4E3047692CC5E4810044ACF2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E3047762CC5E4820044ACF2 /* Preview Assets.xcassets in Resources */,
+				4E3047732CC5E4820044ACF2 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4E3047672CC5E4810044ACF2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E3047712CC5E4810044ACF2 /* TaxiCallView.swift in Sources */,
+				4E30476F2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4E3047772CC5E4820044ACF2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		4E3047782CC5E4820044ACF2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4E30477A2CC5E4820044ACF2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"IssueCard-SwiftUI/Preview Content\"";
+				DEVELOPMENT_TEAM = ZQV4ZDQNW5;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tistory.88yhtserof.IssueCard-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4E30477B2CC5E4820044ACF2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"IssueCard-SwiftUI/Preview Content\"";
+				DEVELOPMENT_TEAM = ZQV4ZDQNW5;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tistory.88yhtserof.IssueCard-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4E3047662CC5E4810044ACF2 /* Build configuration list for PBXProject "IssueCard-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E3047772CC5E4820044ACF2 /* Debug */,
+				4E3047782CC5E4820044ACF2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4E3047792CC5E4820044ACF2 /* Build configuration list for PBXNativeTarget "IssueCard-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E30477A2CC5E4820044ACF2 /* Debug */,
+				4E30477B2CC5E4820044ACF2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4E3047632CC5E4810044ACF2 /* Project object */;
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4E3047712CC5E4810044ACF2 /* TaxiCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */; };
 		4E3047732CC5E4820044ACF2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E3047722CC5E4820044ACF2 /* Assets.xcassets */; };
 		4E3047762CC5E4820044ACF2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E3047752CC5E4820044ACF2 /* Preview Assets.xcassets */; };
+		4E3047802CC62F670044ACF2 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E30477F2CC62F670044ACF2 /* MapView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +20,7 @@
 		4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiCallView.swift; sourceTree = "<group>"; };
 		4E3047722CC5E4820044ACF2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4E3047752CC5E4820044ACF2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		4E30477F2CC62F670044ACF2 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +73,7 @@
 			isa = PBXGroup;
 			children = (
 				4E3047702CC5E4810044ACF2 /* TaxiCallView.swift */,
+				4E30477F2CC62F670044ACF2 /* MapView.swift */,
 			);
 			path = Isuue1;
 			sourceTree = "<group>";
@@ -146,6 +149,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4E3047712CC5E4810044ACF2 /* TaxiCallView.swift in Sources */,
+				4E3047802CC62F670044ACF2 /* MapView.swift in Sources */,
 				4E30476F2CC5E4810044ACF2 /* IssueCard_SwiftUIApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/xcuserdata/linkagelab.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI.xcodeproj/xcuserdata/linkagelab.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>IssueCard-SwiftUI.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Assets.xcassets/Contents.json
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/IssueCard_SwiftUIApp.swift
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/IssueCard_SwiftUIApp.swift
@@ -1,0 +1,17 @@
+//
+//  IssueCard_SwiftUIApp.swift
+//  IssueCard-SwiftUI
+//
+//  Created by 링키지랩 on 10/21/24.
+//
+
+import SwiftUI
+
+@main
+struct IssueCard_SwiftUIApp: App {
+    var body: some Scene {
+        WindowGroup {
+            TaxiCallView()
+        }
+    }
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/MapView.swift
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/MapView.swift
@@ -1,0 +1,28 @@
+//
+//  MapView.swift
+//  IssueCard-SwiftUI
+//
+//  Created by 링키지랩 on 10/21/24.
+//
+
+import SwiftUI
+import MapKit
+
+struct MapView: View {
+    
+    let linkagelab = CLLocationCoordinate2D(latitude: 37.544773, longitude: 127.053746)
+    
+    
+    var body: some View {
+        Map {
+            Marker("LinkageLab", coordinate: linkagelab)
+                .tint(.orange)
+        }
+    }
+}
+
+struct MapView_Previews: PreviewProvider {
+    static var previews: some View {
+        MapView()
+    }
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import MapKit
 
+// 순차 탐색
 struct TaxiCallView: View {
     
     var category = "일반택시"
@@ -20,10 +21,8 @@ struct TaxiCallView: View {
             .joined(separator: " ")
     }
     
-    
     var body: some View {
         MapView()
-//            .accessibilitySortPriority(0.5)
         
         ZStack {
             VStack {
@@ -36,9 +35,8 @@ struct TaxiCallView: View {
             .cornerRadius(10)
             .padding(.horizontal)
             .padding(.top)
-            .accessibilityElement()
+            .accessibilitySortPriority(0.5)
             .accessibilityLabel(accessibilityTaxiInfo)
-//            .accessibilitySortPriority(0.3)
             
             HStack {
                 Image(systemName: "car")
@@ -57,7 +55,6 @@ struct TaxiCallView: View {
                         }
                         .accessibilityElement()
                         .accessibilityLabel(estimatedFare)
-//                        .accessibilitySortPriority(0.1)
                     }
                     
                     HStack {
@@ -73,6 +70,7 @@ struct TaxiCallView: View {
             .padding(.top)
         }
         .fixedSize(horizontal: true, vertical: true)
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
@@ -7,34 +7,28 @@
 
 import SwiftUI
 import MapKit
+
 struct TaxiCallView: View {
+    
+    var category = "일반택시"
+    var capacity = "주변 4인승 택시 호출"
+    var estimatedArrivalTime = "3분"
+    var estimatedFare = "예상 22,000"
+    
+    var accessibilityTaxiInfo: String {
+        [ category, capacity, estimatedArrivalTime ]
+            .joined(separator: " ")
+    }
+    
+    
     var body: some View {
         MapView()
-        VStack {
-            HStack {
-                Image(systemName: "car")
-//                    .frame(width: 50, height: 50)
-                    .padding(.leading)
-                
-                VStack {
-                    HStack {
-                        Text("일반택시")
-                        
-                        Spacer()
-                        
-                        HStack {
-                            Image(systemName: "info.circle")
-                            Text("예상 22,000")
-                        }
-                    }
-                    HStack {
-                        Text("주변 4인승 택시 호출")
-                        Text("3분")
-                        Spacer()
-                    }
-                }
-                .padding(.leading)
-                .padding(.trailing, 20)
+//            .accessibilitySortPriority(0.5)
+        
+        ZStack {
+            VStack {
+                Color.clear
+                    .contentShape(Rectangle())
             }
             .frame(height: 100)
             .frame(maxWidth: 380)
@@ -42,12 +36,43 @@ struct TaxiCallView: View {
             .cornerRadius(10)
             .padding(.horizontal)
             .padding(.top)
+            .accessibilityElement()
+            .accessibilityLabel(accessibilityTaxiInfo)
+//            .accessibilitySortPriority(0.3)
             
-            
+            HStack {
+                Image(systemName: "car")
+                    .padding(.leading)
+                    .frame(width: 50, height: 50)
+                    .accessibilityHidden(true)
+                
+                VStack {
+                    HStack {
+                        Text(category)
+                            .accessibilityHidden(true)
+                        Spacer()
+                        HStack {
+                            Image(systemName: "info.circle")
+                            Text(estimatedFare)
+                        }
+                        .accessibilityElement()
+                        .accessibilityLabel(estimatedFare)
+//                        .accessibilitySortPriority(0.1)
+                    }
+                    
+                    HStack {
+                        Text(capacity)
+                        Text(estimatedArrivalTime)
+                        Spacer()
+                    }
+                    .accessibilityHidden(true)
+                }
+                .padding(.trailing, 20)
+            }
+            .padding(.horizontal)
+            .padding(.top)
         }
-        .frame(maxWidth: .infinity)
-        .background(.white)
-        .cornerRadius(10)
+        .fixedSize(horizontal: true, vertical: true)
     }
 }
 

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
@@ -1,0 +1,20 @@
+//
+//  TaxiCallView.swift
+//  IssueCard-SwiftUI
+//
+//  Created by 링키지랩 on 10/21/24.
+//
+
+import SwiftUI
+import MapKit
+struct TaxiCallView: View {
+    var body: some View {
+        VStack{
+            
+        }
+    }
+}
+
+#Preview {
+    TaxiCallView()
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView.swift
@@ -9,9 +9,45 @@ import SwiftUI
 import MapKit
 struct TaxiCallView: View {
     var body: some View {
-        VStack{
+        MapView()
+        VStack {
+            HStack {
+                Image(systemName: "car")
+//                    .frame(width: 50, height: 50)
+                    .padding(.leading)
+                
+                VStack {
+                    HStack {
+                        Text("일반택시")
+                        
+                        Spacer()
+                        
+                        HStack {
+                            Image(systemName: "info.circle")
+                            Text("예상 22,000")
+                        }
+                    }
+                    HStack {
+                        Text("주변 4인승 택시 호출")
+                        Text("3분")
+                        Spacer()
+                    }
+                }
+                .padding(.leading)
+                .padding(.trailing, 20)
+            }
+            .frame(height: 100)
+            .frame(maxWidth: 380)
+            .background(Color(red: 235 / 255, green: 247 / 255, blue: 255 / 255))
+            .cornerRadius(10)
+            .padding(.horizontal)
+            .padding(.top)
+            
             
         }
+        .frame(maxWidth: .infinity)
+        .background(.white)
+        .cornerRadius(10)
     }
 }
 

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView2.swift
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Isuue1/TaxiCallView2.swift
@@ -1,0 +1,79 @@
+//
+//  TaxiCallView2.swift
+//  IssueCard-SwiftUI
+//
+//  Created by 임윤휘 on 10/23/24.
+//
+
+import SwiftUI
+import MapKit
+
+// 임의 탐색
+struct TaxiCallView2: View {
+    
+    var category = "일반택시"
+    var capacity = "주변 4인승 택시 호출"
+    var estimatedArrivalTime = "3분"
+    var estimatedFare = "예상 22,000"
+    
+    var accessibilityTaxiInfo: String {
+        [ category, capacity, estimatedArrivalTime ]
+            .joined(separator: " ")
+    }
+    
+    var body: some View {
+        MapView()
+        
+        ZStack {
+            VStack {
+                Color.clear
+                    .contentShape(Rectangle())
+            }
+            .frame(height: 100)
+            .frame(maxWidth: 380)
+            .background(Color(red: 235 / 255, green: 247 / 255, blue: 255 / 255))
+            .cornerRadius(10)
+            .padding(.horizontal)
+            .padding(.top)
+            .accessibilityElement()
+            .accessibilityLabel(accessibilityTaxiInfo)
+            
+            HStack {
+                Image(systemName: "car")
+                    .padding(.leading)
+                    .frame(width: 50, height: 50)
+                    .accessibilityHidden(true)
+                
+                VStack {
+                    HStack {
+                        Text(category)
+                            .accessibilityHidden(true)
+                        Spacer()
+                        HStack {
+                            Image(systemName: "info.circle")
+                            Text(estimatedFare)
+                        }
+                        .accessibilityElement()
+                        .accessibilityLabel(estimatedFare)
+                    }
+                    
+                    HStack {
+                        Text(capacity)
+                        Text(estimatedArrivalTime)
+                        Spacer()
+                    }
+                    .accessibilityHidden(true)
+                }
+                .padding(.trailing, 20)
+            }
+            .padding(.horizontal)
+            .padding(.top)
+        }
+        .fixedSize(horizontal: true, vertical: true)
+        .accessibilityElement(children: .contain)
+    }
+}
+
+#Preview {
+    TaxiCallView2()
+}

--- a/IssueCard-SwiftUI/IssueCard-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/IssueCard-SwiftUI/IssueCard-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 이슈

- 순차탐색은 가능하지만 임의탐색이 불가능하다.

<br>


## 작업 결과

- TaxiCallView: 순차 탐색의 순서 보장 시 임의 탐색 불가
- TaxiCallView2: 임의 탐색을 제공하는 경우 순차탐색 불가

### 임의 탐색 제공

임의 탐색을 구현하기 위해 `ZStack`을 사용해 뷰를 상하위 관계로 종속하지 않고 동일한 단계에 배치하는 형식으로 구성했습니다. 그리고 **배경화면**과 **예상 금액** 을 제외한 다른 뷰들을 `accessibilityHidden` 처리해 두 곳에만 초점이 갈 수 있도록 구현했습니다. 

위와 같은 방식으로 순차탐색과 임의탐색을 모두 제공했지만, 순차탐색의 경우 접근 순서에 문제가 발생했습니다.

> 예상 금액(내부) → 배경화면(외부)
> 

이를 개선하기 위해 `accessibilitySortPriority` 를 사용해 초점의 우선순위를 설정했습니다. 하지만 이렇게 되면 순차탐색은 가능하지만 임의탐색이 불가하다는 문제가 발생합니다.

### Priority와 임의탐색

Priority 설정이 왜 임의 탐색에 영향을 주는지 추측을 해보았습니다. 임의탐색이 가능했던 이유는 `배경화면`과 `예상 금액`  뷰를 상하위 관계가 아닌 동일한 단계에 배치했기 때문입니다. 하지만 화면은 많은 뷰들이 쌓여 만들어지기 때문에 프로그래밍상 두 뷰를 동일한 계층에 둔다고 하더라도 하나는 다른 하나에 가려지게 됩니다.  

Prority를 설정하게 되면 프로그래밍 상 순서가 아닌 임의로 우선순위를 정하는 것이기 때문에, 
프로그래밍을 따르는 순차 탐색과는 다르게 쌓여진 뷰의 최상단에서 터치된 영역을 파악해 초점을 설정하는 임의 탐색은 가려진(또는 하위의) 뷰에 접근이 불가능한 것으로 파악됩니다.


<br>

## 결론

순차탐색은 모든 컴포넌트를 순회할 수 있기에 가장 기본적이고 우선되어야 하는 탐색 방법입니다. 임의 탐색의 경우 대략적인 구조 파악 또는 빠른 탐색을 위해 사용하므로 순차 탐색이 더 중요하다고 생각됩니다. 따라서 순서가 보장된 순차탐색 또는 임의탐색 중 하나를 선택해야 한다면 순서 보장 순차탐색을 선택하는 것이 좋을 것 같습니다.

하지만 가장 좋은 방식은 목적이 다른 컴포넌트를 한 컨테이너에 두지 않는 것입니다. 
카카오T의 다른 화면에서는 아래와 같이 분리되어 있습니다. 이렇게 되면 순서 보장 순차탐색/임의탐색 모두 제공할 수 있기 때문에 가장 좋은 방식이라 생각됩니다.

<img src = "https://github.com/user-attachments/assets/0e80fd86-ce7d-4def-ab09-5818fed8f7eb" width = 200 height = 160> 

<br>

## 구현 미리보기
| 순차 탐색(순서 보장) | 임의 탐색 |
| ----- | ----- |
|  <img src = "https://github.com/user-attachments/assets/25abf4b8-3152-47b1-be4d-2b2809275628" width = 200 height = 400> |  <img src = "https://github.com/user-attachments/assets/acd42dd2-97fa-415f-93ef-f01b81dccb21" width = 200 height = 400> |



<br>




#71 