### PR TITLE
[Search] ui/feat: 최근 검색어

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		1488353A2CC513BD0015EA41 /* TableWithAccessibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148835392CC513BD0015EA41 /* TableWithAccessibilityViewController.swift */; };
 		1488353C2CC513E40015EA41 /* TableWithAccessibilityViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1488353B2CC513E40015EA41 /* TableWithAccessibilityViewController+DataSource.swift */; };
 		1488353E2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1488353D2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift */; };
+		149991AF2CCB2D8F0036BE94 /* RecentEmptyListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991AE2CCB2D8F0036BE94 /* RecentEmptyListCell.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -153,6 +154,7 @@
 		148835392CC513BD0015EA41 /* TableWithAccessibilityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableWithAccessibilityViewController.swift; sourceTree = "<group>"; };
 		1488353B2CC513E40015EA41 /* TableWithAccessibilityViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableWithAccessibilityViewController+DataSource.swift"; sourceTree = "<group>"; };
 		1488353D2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableWithAccessibilityViewController+Delegate.swift"; sourceTree = "<group>"; };
+		149991AE2CCB2D8F0036BE94 /* RecentEmptyListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentEmptyListCell.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -504,6 +506,7 @@
 				4E5076992CC8C791006A84D7 /* RecentSearchViewController+Updating.swift */,
 				4EC05A5B2CC9D8EB0062E0D0 /* RecentSearchViewController+Type.swift */,
 				4EC05A592CC9D0400062E0D0 /* RecentListCell.swift */,
+				149991AE2CCB2D8F0036BE94 /* RecentEmptyListCell.swift */,
 			);
 			path = RecentSearchViewController;
 			sourceTree = "<group>";
@@ -835,6 +838,7 @@
 				4EC52AF92CA13F3E007E07D6 /* CollectionViewController+Type.swift in Sources */,
 				4EC52AF12CA13728007E07D6 /* GridTextCell.swift in Sources */,
 				4E0AB0472C9BD22200B8A89C /* DefaultTextField.swift in Sources */,
+				149991AF2CCB2D8F0036BE94 /* RecentEmptyListCell.swift in Sources */,
 				144564262CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift in Sources */,
 				4EC52B092CA16D95007E07D6 /* PageViewController.swift in Sources */,
 				4E5076942CC8C5E0006A84D7 /* RecentSearchViewController.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		1488353C2CC513E40015EA41 /* TableWithAccessibilityViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1488353B2CC513E40015EA41 /* TableWithAccessibilityViewController+DataSource.swift */; };
 		1488353E2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1488353D2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift */; };
 		149991AF2CCB2D8F0036BE94 /* RecentEmptyListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991AE2CCB2D8F0036BE94 /* RecentEmptyListCell.swift */; };
+		149991B12CCB3A0C0036BE94 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991B02CCB3A0C0036BE94 /* UserInfo.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -155,6 +156,7 @@
 		1488353B2CC513E40015EA41 /* TableWithAccessibilityViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableWithAccessibilityViewController+DataSource.swift"; sourceTree = "<group>"; };
 		1488353D2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableWithAccessibilityViewController+Delegate.swift"; sourceTree = "<group>"; };
 		149991AE2CCB2D8F0036BE94 /* RecentEmptyListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentEmptyListCell.swift; sourceTree = "<group>"; };
+		149991B02CCB3A0C0036BE94 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 				4E612E542CB502E9004FAFA0 /* PublicHoliday.swift */,
 				4EB122FB2CB7821A00D771D3 /* News.swift */,
 				4EB123012CB7A71300D771D3 /* Pagable.swift */,
+				149991B02CCB3A0C0036BE94 /* UserInfo.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -803,6 +806,7 @@
 				4E31E0F32C927621004C4979 /* DateAndTimeViewController+Action.swift in Sources */,
 				4ECD49782C8E9B6000F3BEC7 /* AppDelegate.swift in Sources */,
 				4E0925192CA4EC5D00474A16 /* WiFi.swift in Sources */,
+				149991B12CCB3A0C0036BE94 /* UserInfo.swift in Sources */,
 				1488353E2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift in Sources */,
 				4EC52B0C2CA19D57007E07D6 /* PresentationAndMenuViewController.swift in Sources */,
 				4E855F562CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -38,6 +38,12 @@
 		1488353E2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1488353D2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift */; };
 		149991AF2CCB2D8F0036BE94 /* RecentEmptyListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991AE2CCB2D8F0036BE94 /* RecentEmptyListCell.swift */; };
 		149991B12CCB3A0C0036BE94 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991B02CCB3A0C0036BE94 /* UserInfo.swift */; };
+		149991B42CCB45710036BE94 /* RecentSearchWithAccessibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991B32CCB45710036BE94 /* RecentSearchWithAccessibilityViewController.swift */; };
+		149991B62CCB45B10036BE94 /* RecentSearchWithAccessibilityViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991B52CCB45B10036BE94 /* RecentSearchWithAccessibilityViewController+DataSource.swift */; };
+		149991B82CCB45BD0036BE94 /* RecentSearchWithAccessibilityViewController+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991B72CCB45BD0036BE94 /* RecentSearchWithAccessibilityViewController+Delegate.swift */; };
+		149991BA2CCB45DA0036BE94 /* RecentSearchWithAccessibilityViewController+ListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991B92CCB45DA0036BE94 /* RecentSearchWithAccessibilityViewController+ListLayout.swift */; };
+		149991BC2CCB45E60036BE94 /* RecentSearchWithAccessibilityViewController+Updating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991BB2CCB45E60036BE94 /* RecentSearchWithAccessibilityViewController+Updating.swift */; };
+		149991BE2CCB45EF0036BE94 /* RecentSearchWithAccessibilityViewController+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149991BD2CCB45EF0036BE94 /* RecentSearchWithAccessibilityViewController+Type.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -157,6 +163,12 @@
 		1488353D2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableWithAccessibilityViewController+Delegate.swift"; sourceTree = "<group>"; };
 		149991AE2CCB2D8F0036BE94 /* RecentEmptyListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentEmptyListCell.swift; sourceTree = "<group>"; };
 		149991B02CCB3A0C0036BE94 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+		149991B32CCB45710036BE94 /* RecentSearchWithAccessibilityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchWithAccessibilityViewController.swift; sourceTree = "<group>"; };
+		149991B52CCB45B10036BE94 /* RecentSearchWithAccessibilityViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchWithAccessibilityViewController+DataSource.swift"; sourceTree = "<group>"; };
+		149991B72CCB45BD0036BE94 /* RecentSearchWithAccessibilityViewController+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchWithAccessibilityViewController+Delegate.swift"; sourceTree = "<group>"; };
+		149991B92CCB45DA0036BE94 /* RecentSearchWithAccessibilityViewController+ListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchWithAccessibilityViewController+ListLayout.swift"; sourceTree = "<group>"; };
+		149991BB2CCB45E60036BE94 /* RecentSearchWithAccessibilityViewController+Updating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchWithAccessibilityViewController+Updating.swift"; sourceTree = "<group>"; };
+		149991BD2CCB45EF0036BE94 /* RecentSearchWithAccessibilityViewController+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchWithAccessibilityViewController+Type.swift"; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -310,6 +322,19 @@
 			path = TableWithAccessibilityViewController;
 			sourceTree = "<group>";
 		};
+		149991B22CCB45450036BE94 /* RecentSearchWithAccessibilityViewController */ = {
+			isa = PBXGroup;
+			children = (
+				149991B32CCB45710036BE94 /* RecentSearchWithAccessibilityViewController.swift */,
+				149991B52CCB45B10036BE94 /* RecentSearchWithAccessibilityViewController+DataSource.swift */,
+				149991B72CCB45BD0036BE94 /* RecentSearchWithAccessibilityViewController+Delegate.swift */,
+				149991B92CCB45DA0036BE94 /* RecentSearchWithAccessibilityViewController+ListLayout.swift */,
+				149991BB2CCB45E60036BE94 /* RecentSearchWithAccessibilityViewController+Updating.swift */,
+				149991BD2CCB45EF0036BE94 /* RecentSearchWithAccessibilityViewController+Type.swift */,
+			);
+			path = RecentSearchWithAccessibilityViewController;
+			sourceTree = "<group>";
+		};
 		14F7FC3C2CB2C89300F3FA61 /* SearchViewControllerWithAccessibility */ = {
 			isa = PBXGroup;
 			children = (
@@ -369,6 +394,7 @@
 				4EC52AD72C9CFD8B007E07D6 /* SearchViewController */,
 				14F7FC3C2CB2C89300F3FA61 /* SearchViewControllerWithAccessibility */,
 				4E5076922CC8C5B7006A84D7 /* RecentSearchViewController */,
+				149991B22CCB45450036BE94 /* RecentSearchWithAccessibilityViewController */,
 			);
 			path = Text;
 			sourceTree = "<group>";
@@ -780,6 +806,7 @@
 				4E12CE4D2CA27BD4004DF1EA /* DefaultWithScrollViewController.swift in Sources */,
 				4E285DC52C901C68007F286C /* StateViewController.swift in Sources */,
 				4EC51C952C911B8500385BD0 /* StateViewController+Action.swift in Sources */,
+				149991BE2CCB45EF0036BE94 /* RecentSearchWithAccessibilityViewController+Type.swift in Sources */,
 				1445642C2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift in Sources */,
 				4EC52B002CA14976007E07D6 /* TableViewController+Delegate.swift in Sources */,
 				4EC51C972C91226300385BD0 /* OutlineViewController.swift in Sources */,
@@ -790,6 +817,8 @@
 				4EC52AFE2CA145C0007E07D6 /* TableViewController+DataSource.swift in Sources */,
 				1445642A2CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift in Sources */,
 				144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */,
+				149991B82CCB45BD0036BE94 /* RecentSearchWithAccessibilityViewController+Delegate.swift in Sources */,
+				149991BC2CCB45E60036BE94 /* RecentSearchWithAccessibilityViewController+Updating.swift in Sources */,
 				4EC05A602CC9E70D0062E0D0 /* RecentSearchViewController+ListLayout.swift in Sources */,
 				4ED71CE52CA6392F00A1A724 /* AccessibilityListCell.swift in Sources */,
 				4EC52AE12C9D1590007E07D6 /* SwitchViewController+DataSource.swift in Sources */,
@@ -809,6 +838,7 @@
 				149991B12CCB3A0C0036BE94 /* UserInfo.swift in Sources */,
 				1488353E2CC513EE0015EA41 /* TableWithAccessibilityViewController+Delegate.swift in Sources */,
 				4EC52B0C2CA19D57007E07D6 /* PresentationAndMenuViewController.swift in Sources */,
+				149991B42CCB45710036BE94 /* RecentSearchWithAccessibilityViewController.swift in Sources */,
 				4E855F562CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift in Sources */,
 				4E1BC4F72CAF7244001A29D5 /* SearchViewController+Updating.swift in Sources */,
 				144FC6FA2CBCE8B000CC75FE /* TodayCollectionListCell.swift in Sources */,
@@ -828,6 +858,7 @@
 				4EC51C9C2C91295200385BD0 /* Outline.swift in Sources */,
 				4EF982172C93FCDC00809294 /* AlertViewController+Action.swift in Sources */,
 				4EB123042CB7B0C300D771D3 /* NewsListViewControllerWithAccessibility.swift in Sources */,
+				149991BA2CCB45DA0036BE94 /* RecentSearchWithAccessibilityViewController+ListLayout.swift in Sources */,
 				148835332CC50FF30015EA41 /* CollectionWithAccessibilityViewController+DataSource.swift in Sources */,
 				4E0AB0502C9BEF2800B8A89C /* SearchViewController.swift in Sources */,
 				4E12CE4B2CA2482F004DF1EA /* Titleable.swift in Sources */,
@@ -838,6 +869,7 @@
 				4EC52AF52CA13925007E07D6 /* View+Constraints.swift in Sources */,
 				4EC52AE32C9D19D8007E07D6 /* SwitchViewController+Action.swift in Sources */,
 				4E5076962CC8C76E006A84D7 /* RecentSearchViewController+DataSource.swift in Sources */,
+				149991B62CCB45B10036BE94 /* RecentSearchWithAccessibilityViewController+DataSource.swift in Sources */,
 				4ECD497A2C8E9B6000F3BEC7 /* SceneDelegate.swift in Sources */,
 				4EC52AF92CA13F3E007E07D6 /* CollectionViewController+Type.swift in Sources */,
 				4EC52AF12CA13728007E07D6 /* GridTextCell.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -61,6 +61,10 @@
 		4E285DC52C901C68007F286C /* StateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E285DC42C901C68007F286C /* StateViewController.swift */; };
 		4E31E0F02C927024004C4979 /* DateFormatterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E31E0EF2C927024004C4979 /* DateFormatterManager.swift */; };
 		4E31E0F32C927621004C4979 /* DateAndTimeViewController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E31E0F22C927621004C4979 /* DateAndTimeViewController+Action.swift */; };
+		4E5076942CC8C5E0006A84D7 /* RecentSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5076932CC8C5E0006A84D7 /* RecentSearchViewController.swift */; };
+		4E5076962CC8C76E006A84D7 /* RecentSearchViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5076952CC8C76E006A84D7 /* RecentSearchViewController+DataSource.swift */; };
+		4E5076982CC8C77A006A84D7 /* RecentSearchViewController+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5076972CC8C77A006A84D7 /* RecentSearchViewController+Delegate.swift */; };
+		4E50769A2CC8C791006A84D7 /* RecentSearchViewController+Updating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5076992CC8C791006A84D7 /* RecentSearchViewController+Updating.swift */; };
 		4E612E532CB4BB09004FAFA0 /* DynamicTypeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E612E522CB4BB09004FAFA0 /* DynamicTypeable.swift */; };
 		4E612E552CB502E9004FAFA0 /* PublicHoliday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E612E542CB502E9004FAFA0 /* PublicHoliday.swift */; };
 		4E855F542CACE15C008CDB3B /* DefaultCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E855F532CACE15C008CDB3B /* DefaultCollectionViewController.swift */; };
@@ -76,6 +80,10 @@
 		4EB123042CB7B0C300D771D3 /* NewsListViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB123032CB7B0C300D771D3 /* NewsListViewControllerWithAccessibility.swift */; };
 		4EB123062CB7B57900D771D3 /* NewsListCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB123052CB7B57900D771D3 /* NewsListCellWithAccessibility.swift */; };
 		4EBB491B2CA3D63C006FD702 /* TextViewController+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EBB491A2CA3D63C006FD702 /* TextViewController+Delegate.swift */; };
+		4EC05A5A2CC9D0400062E0D0 /* RecentListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC05A592CC9D0400062E0D0 /* RecentListCell.swift */; };
+		4EC05A5C2CC9D8EB0062E0D0 /* RecentSearchViewController+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC05A5B2CC9D8EB0062E0D0 /* RecentSearchViewController+Type.swift */; };
+		4EC05A602CC9E70D0062E0D0 /* RecentSearchViewController+ListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC05A5F2CC9E70D0062E0D0 /* RecentSearchViewController+ListLayout.swift */; };
+		4EC05A622CC9F33D0062E0D0 /* PreferredContentSizeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC05A612CC9F33D0062E0D0 /* PreferredContentSizeManager.swift */; };
 		4EC51C952C911B8500385BD0 /* StateViewController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC51C942C911B8500385BD0 /* StateViewController+Action.swift */; };
 		4EC51C972C91226300385BD0 /* OutlineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC51C962C91226300385BD0 /* OutlineViewController.swift */; };
 		4EC51C9A2C9128C400385BD0 /* OutLineViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC51C992C9128C400385BD0 /* OutLineViewController+DataSource.swift */; };
@@ -170,6 +178,10 @@
 		4E285DC42C901C68007F286C /* StateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateViewController.swift; sourceTree = "<group>"; };
 		4E31E0EF2C927024004C4979 /* DateFormatterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterManager.swift; sourceTree = "<group>"; };
 		4E31E0F22C927621004C4979 /* DateAndTimeViewController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateAndTimeViewController+Action.swift"; sourceTree = "<group>"; };
+		4E5076932CC8C5E0006A84D7 /* RecentSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchViewController.swift; sourceTree = "<group>"; };
+		4E5076952CC8C76E006A84D7 /* RecentSearchViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchViewController+DataSource.swift"; sourceTree = "<group>"; };
+		4E5076972CC8C77A006A84D7 /* RecentSearchViewController+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchViewController+Delegate.swift"; sourceTree = "<group>"; };
+		4E5076992CC8C791006A84D7 /* RecentSearchViewController+Updating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchViewController+Updating.swift"; sourceTree = "<group>"; };
 		4E612E522CB4BB09004FAFA0 /* DynamicTypeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeable.swift; sourceTree = "<group>"; };
 		4E612E542CB502E9004FAFA0 /* PublicHoliday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicHoliday.swift; sourceTree = "<group>"; };
 		4E855F532CACE15C008CDB3B /* DefaultCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCollectionViewController.swift; sourceTree = "<group>"; };
@@ -186,6 +198,10 @@
 		4EB123052CB7B57900D771D3 /* NewsListCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsListCellWithAccessibility.swift; sourceTree = "<group>"; };
 		4EBB491A2CA3D63C006FD702 /* TextViewController+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextViewController+Delegate.swift"; sourceTree = "<group>"; };
 		4EBB491C2CA3E014006FD702 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		4EC05A592CC9D0400062E0D0 /* RecentListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentListCell.swift; sourceTree = "<group>"; };
+		4EC05A5B2CC9D8EB0062E0D0 /* RecentSearchViewController+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchViewController+Type.swift"; sourceTree = "<group>"; };
+		4EC05A5F2CC9E70D0062E0D0 /* RecentSearchViewController+ListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchViewController+ListLayout.swift"; sourceTree = "<group>"; };
+		4EC05A612CC9F33D0062E0D0 /* PreferredContentSizeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredContentSizeManager.swift; sourceTree = "<group>"; };
 		4EC51C942C911B8500385BD0 /* StateViewController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StateViewController+Action.swift"; sourceTree = "<group>"; };
 		4EC51C962C91226300385BD0 /* OutlineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineViewController.swift; sourceTree = "<group>"; };
 		4EC51C992C9128C400385BD0 /* OutLineViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OutLineViewController+DataSource.swift"; sourceTree = "<group>"; };
@@ -348,6 +364,7 @@
 				4E0AB04B2C9BE1DA00B8A89C /* TextViewController */,
 				4EC52AD72C9CFD8B007E07D6 /* SearchViewController */,
 				14F7FC3C2CB2C89300F3FA61 /* SearchViewControllerWithAccessibility */,
+				4E5076922CC8C5B7006A84D7 /* RecentSearchViewController */,
 			);
 			path = Text;
 			sourceTree = "<group>";
@@ -435,6 +452,7 @@
 			children = (
 				4E31E0EF2C927024004C4979 /* DateFormatterManager.swift */,
 				4EC52AE62C9D36F4007E07D6 /* ImageLoader.swift */,
+				4EC05A612CC9F33D0062E0D0 /* PreferredContentSizeManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -474,6 +492,20 @@
 				4E12CE522CA28AAF004DF1EA /* DateAndTimeViewController */,
 			);
 			path = DateAndTime;
+			sourceTree = "<group>";
+		};
+		4E5076922CC8C5B7006A84D7 /* RecentSearchViewController */ = {
+			isa = PBXGroup;
+			children = (
+				4E5076932CC8C5E0006A84D7 /* RecentSearchViewController.swift */,
+				4E5076952CC8C76E006A84D7 /* RecentSearchViewController+DataSource.swift */,
+				4E5076972CC8C77A006A84D7 /* RecentSearchViewController+Delegate.swift */,
+				4EC05A5F2CC9E70D0062E0D0 /* RecentSearchViewController+ListLayout.swift */,
+				4E5076992CC8C791006A84D7 /* RecentSearchViewController+Updating.swift */,
+				4EC05A5B2CC9D8EB0062E0D0 /* RecentSearchViewController+Type.swift */,
+				4EC05A592CC9D0400062E0D0 /* RecentListCell.swift */,
+			);
+			path = RecentSearchViewController;
 			sourceTree = "<group>";
 		};
 		4E855F522CACE13D008CDB3B /* DefaultCollectionViewController */ = {
@@ -735,8 +767,10 @@
 				4EC52AE72C9D36F4007E07D6 /* ImageLoader.swift in Sources */,
 				4EC52AEB2CA11594007E07D6 /* DateAndTimeViewController+Delegate.swift in Sources */,
 				4EC52AEF2CA1359F007E07D6 /* CollectionViewController+DataSource.swift in Sources */,
+				4E5076982CC8C77A006A84D7 /* RecentSearchViewController+Delegate.swift in Sources */,
 				144564222CBB932B0097DF89 /* MelonChartNavigationViewController.swift in Sources */,
 				14852BE52CC1FA4800F53857 /* NewsListViewControllerWithAccessibility+Delegate.swift in Sources */,
+				4EC05A622CC9F33D0062E0D0 /* PreferredContentSizeManager.swift in Sources */,
 				4E12CE4D2CA27BD4004DF1EA /* DefaultWithScrollViewController.swift in Sources */,
 				4E285DC52C901C68007F286C /* StateViewController.swift in Sources */,
 				4EC51C952C911B8500385BD0 /* StateViewController+Action.swift in Sources */,
@@ -750,6 +784,7 @@
 				4EC52AFE2CA145C0007E07D6 /* TableViewController+DataSource.swift in Sources */,
 				1445642A2CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift in Sources */,
 				144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */,
+				4EC05A602CC9E70D0062E0D0 /* RecentSearchViewController+ListLayout.swift in Sources */,
 				4ED71CE52CA6392F00A1A724 /* AccessibilityListCell.swift in Sources */,
 				4EC52AE12C9D1590007E07D6 /* SwitchViewController+DataSource.swift in Sources */,
 				4E0AB0492C9BDD9900B8A89C /* TextViewController.swift in Sources */,
@@ -770,6 +805,7 @@
 				4E855F562CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift in Sources */,
 				4E1BC4F72CAF7244001A29D5 /* SearchViewController+Updating.swift in Sources */,
 				144FC6FA2CBCE8B000CC75FE /* TodayCollectionListCell.swift in Sources */,
+				4E50769A2CC8C791006A84D7 /* RecentSearchViewController+Updating.swift in Sources */,
 				4EB122FA2CB7694300D771D3 /* NewsListCell.swift in Sources */,
 				1488353A2CC513BD0015EA41 /* TableWithAccessibilityViewController.swift in Sources */,
 				14852BEB2CC227DE00F53857 /* MelonListCell.swift in Sources */,
@@ -794,18 +830,22 @@
 				14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */,
 				4EC52AF52CA13925007E07D6 /* View+Constraints.swift in Sources */,
 				4EC52AE32C9D19D8007E07D6 /* SwitchViewController+Action.swift in Sources */,
+				4E5076962CC8C76E006A84D7 /* RecentSearchViewController+DataSource.swift in Sources */,
 				4ECD497A2C8E9B6000F3BEC7 /* SceneDelegate.swift in Sources */,
 				4EC52AF92CA13F3E007E07D6 /* CollectionViewController+Type.swift in Sources */,
 				4EC52AF12CA13728007E07D6 /* GridTextCell.swift in Sources */,
 				4E0AB0472C9BD22200B8A89C /* DefaultTextField.swift in Sources */,
 				144564262CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift in Sources */,
 				4EC52B092CA16D95007E07D6 /* PageViewController.swift in Sources */,
+				4E5076942CC8C5E0006A84D7 /* RecentSearchViewController.swift in Sources */,
 				4EC52AFC2CA144D5007E07D6 /* TableViewController.swift in Sources */,
+				4EC05A5C2CC9D8EB0062E0D0 /* RecentSearchViewController+Type.swift in Sources */,
 				4EC52B142CA1ABC0007E07D6 /* Book.swift in Sources */,
 				4E612E532CB4BB09004FAFA0 /* DynamicTypeable.swift in Sources */,
 				4EC52AED2CA1352F007E07D6 /* CollectionViewController.swift in Sources */,
 				14F7FC472CB2CF6C00F3FA61 /* PageViewControllerWithAccessibility.swift in Sources */,
 				4EF982152C93E4DF00809294 /* AlertViewController.swift in Sources */,
+				4EC05A5A2CC9D0400062E0D0 /* RecentListCell.swift in Sources */,
 				1445642E2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift in Sources */,
 				148835372CC5106C0015EA41 /* CollectionWithAccessibilityViewController+Type.swift in Sources */,
 				4E855F5C2CACF378008CDB3B /* DefaultListCell.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		4E12CE4B2CA2482F004DF1EA /* Titleable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E12CE4A2CA2482F004DF1EA /* Titleable.swift */; };
 		4E12CE4D2CA27BD4004DF1EA /* DefaultWithScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E12CE4C2CA27BD4004DF1EA /* DefaultWithScrollViewController.swift */; };
 		4E1BC4F72CAF7244001A29D5 /* SearchViewController+Updating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1BC4F62CAF7244001A29D5 /* SearchViewController+Updating.swift */; };
-		4E1BC4F92CAF87F9001A29D5 /* UIAccessibility+Focus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1BC4F82CAF87F9001A29D5 /* UIAccessibility+Focus.swift */; };
+		4E1BC4F92CAF87F9001A29D5 /* UIAccessibility+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1BC4F82CAF87F9001A29D5 /* UIAccessibility+.swift */; };
 		4E285DBF2C8FE947007F286C /* ButtonAndSliderViewController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E285DBE2C8FE947007F286C /* ButtonAndSliderViewController+Action.swift */; };
 		4E285DC52C901C68007F286C /* StateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E285DC42C901C68007F286C /* StateViewController.swift */; };
 		4E31E0F02C927024004C4979 /* DateFormatterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E31E0EF2C927024004C4979 /* DateFormatterManager.swift */; };
@@ -189,7 +189,7 @@
 		4E12CE4A2CA2482F004DF1EA /* Titleable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Titleable.swift; sourceTree = "<group>"; };
 		4E12CE4C2CA27BD4004DF1EA /* DefaultWithScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWithScrollViewController.swift; sourceTree = "<group>"; };
 		4E1BC4F62CAF7244001A29D5 /* SearchViewController+Updating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchViewController+Updating.swift"; sourceTree = "<group>"; };
-		4E1BC4F82CAF87F9001A29D5 /* UIAccessibility+Focus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAccessibility+Focus.swift"; sourceTree = "<group>"; };
+		4E1BC4F82CAF87F9001A29D5 /* UIAccessibility+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAccessibility+.swift"; sourceTree = "<group>"; };
 		4E285DBE2C8FE947007F286C /* ButtonAndSliderViewController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ButtonAndSliderViewController+Action.swift"; sourceTree = "<group>"; };
 		4E285DC42C901C68007F286C /* StateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateViewController.swift; sourceTree = "<group>"; };
 		4E31E0EF2C927024004C4979 /* DateFormatterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterManager.swift; sourceTree = "<group>"; };
@@ -371,7 +371,7 @@
 				4E855F5B2CACF378008CDB3B /* DefaultListCell.swift */,
 				14B1303B2CAED6D500877314 /* GrabberView.swift */,
 				4EB122FF2CB793B100D771D3 /* ButtonSupplementaryView.swift */,
-				4E1BC4F82CAF87F9001A29D5 /* UIAccessibility+Focus.swift */,
+				4E1BC4F82CAF87F9001A29D5 /* UIAccessibility+.swift */,
 				14852BE62CC20B4300F53857 /* ButtonTraitsTableCell.swift */,
 				1488352D2CC50B0B0015EA41 /* ButtonTraitsCollectionListCell.swift */,
 			);
@@ -826,7 +826,7 @@
 				4EB123022CB7A71300D771D3 /* Pagable.swift in Sources */,
 				4E12CE492CA244BC004DF1EA /* DefaultViewController.swift in Sources */,
 				4EC52AF32CA138D3007E07D6 /* TitleSupplementaryView.swift in Sources */,
-				4E1BC4F92CAF87F9001A29D5 /* UIAccessibility+Focus.swift in Sources */,
+				4E1BC4F92CAF87F9001A29D5 /* UIAccessibility+.swift in Sources */,
 				144FC6F32CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift in Sources */,
 				144564302CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift in Sources */,
 				4EC52AF72CA13A51007E07D6 /* CollectionView+ListLayout.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
@@ -52,7 +52,9 @@ extension Detail {
     private static let itemsForText = [
         Detail(title: "Label | TextField | TextView"),
         Detail(title: "SearchView ● 기본 컴포넌트"),
-        Detail(title: "SearchView ▲ 개선 컴포넌트")
+        Detail(title: "SearchView ▲ 개선 컴포넌트"),
+        Detail(title: "최신 검색어 ● 기본 컴포넌트"),
+        Detail(title: "최신 검색어 ▲ 개선 컴포넌트")
     ]
     
     private static let itemsForControl = [

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
@@ -53,8 +53,8 @@ extension Detail {
         Detail(title: "Label | TextField | TextView"),
         Detail(title: "SearchView ● 기본 컴포넌트"),
         Detail(title: "SearchView ▲ 개선 컴포넌트"),
-        Detail(title: "최신 검색어 ● 기본 컴포넌트"),
-        Detail(title: "최신 검색어 ▲ 개선 컴포넌트")
+        Detail(title: "최근 검색어 ● 기본 컴포넌트"),
+        Detail(title: "최근 검색어 ▲ 개선 컴포넌트")
     ]
     
     private static let itemsForControl = [

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
@@ -23,16 +23,6 @@ struct Detail: Hashable {
         var title: String {
             self.rawValue
         }
-        
-        var accessibilityLabel: String {
-            return String(title.suffix(title.count - 2))
-        }
-    }
-    
-    var accessibilityLabel: String {
-        title
-            .split(whereSeparator: { ["|", "●", "▲", "⭑"].contains($0) })
-            .joined(separator: ",")
     }
 }
 

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/UserInfo.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/UserInfo.swift
@@ -1,0 +1,45 @@
+//
+//  UserInfo.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+import Foundation
+
+struct UserInfo: Hashable, Identifiable {
+    var id = UUID()
+    var nickname: String
+}
+
+extension UserInfo {
+    static var recents = [
+        UserInfo(nickname: "하퍼"),
+        UserInfo(nickname: "올리"),
+        UserInfo(nickname: "하니"),
+        UserInfo(nickname: "아일라")
+    ]
+    
+    static var samples = [
+        UserInfo(nickname: "하퍼"),
+        UserInfo(nickname: "올리"),
+        UserInfo(nickname: "하니"),
+        UserInfo(nickname: "아일라"),
+        UserInfo(nickname: "칸"),
+        UserInfo(nickname: "아마라"),
+        UserInfo(nickname: "이든"),
+        UserInfo(nickname: "미아"),
+        UserInfo(nickname: "듀이"),
+        UserInfo(nickname: "찰리"),
+        UserInfo(nickname: "듀오"),
+        UserInfo(nickname: "키미"),
+        UserInfo(nickname: "수"),
+        UserInfo(nickname: "곤"),
+        UserInfo(nickname: "제이크"),
+        UserInfo(nickname: "데이비드"),
+        UserInfo(nickname: "줄리안"),
+        UserInfo(nickname: "에리카"),
+        UserInfo(nickname: "조셉"),
+        UserInfo(nickname: "스텔라")
+    ]
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/UserInfo.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/UserInfo.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-struct UserInfo: Hashable, Identifiable {
-    var id = UUID()
+struct UserInfo: Hashable, Equatable {
     var nickname: String
 }
 

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Managers/PreferredContentSizeManager.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Managers/PreferredContentSizeManager.swift
@@ -1,0 +1,54 @@
+//
+//  PreferredContentSizeManager.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/24/24.
+//
+
+import UIKit
+
+struct PreferredContentSizeManager {
+    
+    static var shared = PreferredContentSizeManager()
+    
+    private init() {}
+    
+    var preferredContentSize = UIApplication.shared.preferredContentSizeCategory.rawValue
+    
+    private var categoryTitle: String {
+        get {
+            return UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory ? "UICTContentSizeCategoryAccessibility" : "UICTContentSizeCategory"
+        }
+    }
+    
+    var size: Int {
+        let size = String(preferredContentSize.suffix(preferredContentSize.count - categoryTitle.count))
+        guard let scale = PreferredContentSize(rawValue: size) else { return 2 }
+        switch scale {
+        case .extraSmall:
+            return 1
+        case .small:
+            return 2
+        case .medium:
+            return 3
+        case .large:
+            return 4
+        case .extraLarge:
+            return 5
+        case .extraExtraLarge:
+            return 6
+        case .extraExtraExtraLarg:
+            return 7
+        }
+    }
+    
+    enum PreferredContentSize: String {
+        case extraSmall = "XS"
+        case small = "S"
+        case medium = "M"
+        case large = "L"
+        case extraLarge = "XL"
+        case extraExtraLarge = "XXL"
+        case extraExtraExtraLarg = "XXXL"
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+DataSource.swift
@@ -28,7 +28,7 @@ extension OutlineViewController {
         cell.selectedBackgroundView = UIView()
         cell.accessories = [.disclosureIndicator()]
         if UIAccessibility.isVoiceOverRunning {
-            cell.accessibilityLabel = item.accessibilityLabel
+            cell.accessibilityLabel = item.title
         }
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+Delegate.swift
@@ -83,7 +83,7 @@ extension OutlineViewController: UICollectionViewDelegate {
             return
         }
         
-        vc.navigationTitle = Detail.items[indexPath.section][item].accessibilityLabel
+        vc.navigationTitle = Detail.items[indexPath.section][item].title
         navigationController?.pushViewController(vc as! UIViewController, animated: true)
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+Delegate.swift
@@ -25,6 +25,10 @@ extension OutlineViewController: UICollectionViewDelegate {
                 vc = SearchViewController()
             case 2:
                 vc = SearchViewControllerWithAccessibility()
+            case 3:
+                vc = RecentSearchViewController()
+            case 4:
+                vc = RecentSearchWithAccessibilityViewController()
             default:
                 return
             }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentEmptyListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentEmptyListCell.swift
@@ -1,0 +1,41 @@
+//
+//  RecentEmptyListCell.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+
+import UIKit
+
+final class RecentEmptyListCell: ButtonTraitsCollectionListCell {
+
+    private lazy var emptyLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureEmptyCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension RecentEmptyListCell {
+    
+    func configureEmptyCell() {
+        emptyLabel.text = "검색 내역이 없습니다"
+        setPreferredFontyStyle()
+        backgroundView = UIView()
+        selectedBackgroundView = UIView()
+        contentView.addPinnedSubview(emptyLabel, height: nil)
+    }
+}
+
+extension RecentEmptyListCell: DynamicTypeable {
+    func setPreferredFontyStyle() {
+        emptyLabel.font = UIFont.preferredFont(forTextStyle: .body)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
@@ -11,14 +11,17 @@ final class RecentListCell: ButtonTraitsCollectionListCell {
     
     var text: String = "닉네임" {
         didSet {
-            textLabel.text = text
+            textButtonConfig.title = text
+            textButton.configuration = textButtonConfig
         }
     }
     var deleteAction: (() -> Void)?
+    var textAction: ((String) -> Void)?
     
-    private lazy var textLabel = UILabel()
+    private var textButtonConfig = UIButton.Configuration.plain()
+    private lazy var textButton = UIButton()
     private lazy var deleteButton = UIButton()
-    private lazy var stackView = UIStackView(arrangedSubviews: [textLabel, deleteButton])
+    private lazy var stackView = UIStackView(arrangedSubviews: [textButton, deleteButton])
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -33,6 +36,11 @@ final class RecentListCell: ButtonTraitsCollectionListCell {
     @objc func didTapDeleteButton() {
         deleteAction?()
     }
+    
+    @objc func didTapTextButton(_ sender: UIButton) {
+        guard let searchWord = sender.titleLabel?.text else { return }
+        textAction?(searchWord)
+    }
 }
 
 private extension RecentListCell {
@@ -40,8 +48,9 @@ private extension RecentListCell {
         backgroundView = UIView()
         selectedBackgroundView = UIView()
         
-        textLabel.text = text
+        textButtonConfig.baseForegroundColor = .black
         setPreferredFontyStyle()
+        textButton.addTarget(self, action: #selector(didTapTextButton), for: .touchUpInside)
         
         let deleteImage = UIImage(systemName: "xmark")
         var config = UIButton.Configuration.plain()
@@ -63,6 +72,6 @@ private extension RecentListCell {
 
 extension RecentListCell: DynamicTypeable {
     func setPreferredFontyStyle() {
-        textLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        textButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
@@ -14,19 +14,8 @@ final class RecentListCell: ButtonTraitsCollectionListCell {
             textLabel.text = text
         }
     }
+    var deleteAction: (() -> Void)?
     
-    var identifier: String {
-        get { self.text }
-        set {}
-    }
-    var deleteAction: ((String) -> Void)?
-    var isEmptyCell = false {
-        didSet {
-            configureCotentView()
-        }
-    }
-    
-    private lazy var emptyLabel = UILabel()
     private lazy var textLabel = UILabel()
     private lazy var deleteButton = UIButton()
     private lazy var stackView = UIStackView(arrangedSubviews: [textLabel, deleteButton])
@@ -34,7 +23,7 @@ final class RecentListCell: ButtonTraitsCollectionListCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        configureCotentView()
+        configureContentView()
     }
     
     required init?(coder: NSCoder) {
@@ -42,26 +31,14 @@ final class RecentListCell: ButtonTraitsCollectionListCell {
     }
     
     @objc func didTapDeleteButton() {
-        deleteAction?(identifier)
+        deleteAction?()
     }
 }
 
 private extension RecentListCell {
-    func configureCotentView() {
-        if isEmptyCell {
-            configureEmptyCell()
-        } else {
-            configureStardCell()
-        }
-        
+    func configureContentView() {
         backgroundView = UIView()
         selectedBackgroundView = UIView()
-    }
-    
-    func configureStardCell() {
-        [ textLabel, deleteButton ]
-            .forEach{ $0.isHidden = false }
-        emptyLabel.isHidden = true
         
         textLabel.text = text
         setPreferredFontyStyle()
@@ -82,25 +59,10 @@ private extension RecentListCell {
         
         contentView.addPinnedSubview(stackView, inset: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0), height: nil)
     }
-    
-    func configureEmptyCell() {
-        emptyLabel.text = "검색 내역이 없습니다"
-        setPreferredFontyStyle()
-        
-        [ textLabel, deleteButton ]
-            .forEach{ $0.isHidden = true }
-        emptyLabel.isHidden = false
-        contentView.backgroundColor = nil
-        contentView.addPinnedSubview(emptyLabel, height: nil)
-    }
 }
 
 extension RecentListCell: DynamicTypeable {
     func setPreferredFontyStyle() {
-        if isEmptyCell {
-            emptyLabel.font = UIFont.preferredFont(forTextStyle: .body)
-        } else {
-            textLabel.font = UIFont.preferredFont(forTextStyle: .body)
-        }
+        textLabel.font = UIFont.preferredFont(forTextStyle: .body)
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
@@ -59,6 +59,7 @@ private extension RecentListCell {
         config.buttonSize = .mini
         deleteButton.configuration = config
         deleteButton.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
+        deleteButton.accessibilityLabel = "제거"
         
         stackView.axis = .horizontal
         stackView.distribution = .fill

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentListCell.swift
@@ -1,0 +1,106 @@
+//
+//  File.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/24/24.
+//
+
+import UIKit
+
+final class RecentListCell: ButtonTraitsCollectionListCell {
+    
+    var text: String = "닉네임" {
+        didSet {
+            textLabel.text = text
+        }
+    }
+    
+    var identifier: String {
+        get { self.text }
+        set {}
+    }
+    var deleteAction: ((String) -> Void)?
+    var isEmptyCell = false {
+        didSet {
+            configureCotentView()
+        }
+    }
+    
+    private lazy var emptyLabel = UILabel()
+    private lazy var textLabel = UILabel()
+    private lazy var deleteButton = UIButton()
+    private lazy var stackView = UIStackView(arrangedSubviews: [textLabel, deleteButton])
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureCotentView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc func didTapDeleteButton() {
+        deleteAction?(identifier)
+    }
+}
+
+private extension RecentListCell {
+    func configureCotentView() {
+        if isEmptyCell {
+            configureEmptyCell()
+        } else {
+            configureStardCell()
+        }
+        
+        backgroundView = UIView()
+        selectedBackgroundView = UIView()
+    }
+    
+    func configureStardCell() {
+        [ textLabel, deleteButton ]
+            .forEach{ $0.isHidden = false }
+        emptyLabel.isHidden = true
+        
+        textLabel.text = text
+        setPreferredFontyStyle()
+        
+        let deleteImage = UIImage(systemName: "xmark")
+        var config = UIButton.Configuration.plain()
+        config.image = deleteImage
+        config.baseForegroundColor = .black
+        config.buttonSize = .mini
+        deleteButton.configuration = config
+        deleteButton.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
+        
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 10
+        
+        contentView.addPinnedSubview(stackView, inset: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0), height: nil)
+    }
+    
+    func configureEmptyCell() {
+        emptyLabel.text = "검색 내역이 없습니다"
+        setPreferredFontyStyle()
+        
+        [ textLabel, deleteButton ]
+            .forEach{ $0.isHidden = true }
+        emptyLabel.isHidden = false
+        contentView.backgroundColor = nil
+        contentView.addPinnedSubview(emptyLabel, height: nil)
+    }
+}
+
+extension RecentListCell: DynamicTypeable {
+    func setPreferredFontyStyle() {
+        if isEmptyCell {
+            emptyLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        } else {
+            textLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
@@ -12,16 +12,14 @@ extension RecentSearchViewController {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
     
     func recentCellRegistrationHandler(cell: RecentListCell, indexPath: IndexPath, item: String) {
-        if recents.isEmpty {
-            cell.isEmptyCell = true
-        } else {
-            cell.isEmptyCell = false
-            cell.text = item
-            cell.deleteAction = { [weak self] identifier in
-                let item = Item(recent: identifier)
-                self?.updateSnapshotForRecent(itemToDelete: item)
-            }
+        cell.text = item
+        cell.deleteAction = { [weak self]  in
+            let itemToDelete = Item(recent: item)
+            self?.updateSnapshotForRecent(itemToDelete: itemToDelete)
         }
+    }
+    
+    func recentEmptyCellRegistrationHandler(cell: RecentEmptyListCell, indexPath: IndexPath, item: String) {
     }
     
     func resultCellRegistrationHandler(cell: UICollectionViewListCell, indexPath: IndexPath, item: String) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
@@ -11,8 +11,8 @@ extension RecentSearchViewController {
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
     
-    func recentCellRegistrationHandler(cell: RecentListCell, indexPath: IndexPath, item: String) {
-        cell.text = item
+    func recentCellRegistrationHandler(cell: RecentListCell, indexPath: IndexPath, item: UserInfo) {
+        cell.text = item.nickname
         cell.deleteAction = { [weak self]  in
             let itemToDelete = Item(recent: item)
             self?.updateSnapshotForRecent(itemToDelete: itemToDelete)
@@ -22,12 +22,12 @@ extension RecentSearchViewController {
         }
     }
     
-    func recentEmptyCellRegistrationHandler(cell: RecentEmptyListCell, indexPath: IndexPath, item: String) {
+    func recentEmptyCellRegistrationHandler(cell: RecentEmptyListCell, indexPath: IndexPath, item: Item) {
     }
     
-    func resultCellRegistrationHandler(cell: UICollectionViewListCell, indexPath: IndexPath, item: String) {
+    func resultCellRegistrationHandler(cell: UICollectionViewListCell, indexPath: IndexPath, item: UserInfo) {
         var configuration = UIListContentConfiguration.cell()
-        configuration.text = item
+        configuration.text = item.nickname
         cell.contentConfiguration = configuration
         cell.selectedBackgroundView = UIView()
     }
@@ -41,7 +41,7 @@ extension RecentSearchViewController {
     
     func initialSnapshot() {
         let recentItems = recents.isEmpty ? [Item()] : recents.map({ Item(recent: $0) })
-        let resultItems = samples.map({ Item(result: $0.title) })
+        let resultItems = allUsers.map({ Item(result: $0) })
         
         snapshot = Snapshot()
         snapshot.appendSections([.recent, .result])
@@ -87,9 +87,9 @@ extension RecentSearchViewController {
     
     func filteredSnapshot(searchWord word: String) {
         let resultItems = snapshot.itemIdentifiers(inSection: .result)
-        let filteredItems = samples
-            .map({ Item(result: $0.title) })
-            .filter{ $0.result!.contains(word) }
+        let filteredItems = allUsers
+            .map({ Item(result: $0) })
+            .filter{ $0.result!.nickname.contains(word) }
         snapshot.deleteItems(resultItems)
         snapshot.appendItems(filteredItems, toSection: .result)
         dataSource.apply(snapshot, animatingDifferences: true)

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
@@ -17,6 +17,9 @@ extension RecentSearchViewController {
             let itemToDelete = Item(recent: item)
             self?.updateSnapshotForRecent(itemToDelete: itemToDelete)
         }
+        cell.textAction = { [weak self] searchWord in
+            self?.searchController.searchBar.text = searchWord
+        }
     }
     
     func recentEmptyCellRegistrationHandler(cell: RecentEmptyListCell, indexPath: IndexPath, item: String) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+DataSource.swift
@@ -1,0 +1,96 @@
+//
+//  RecentSearchViewController+DataSource.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/23/24.
+//
+
+import UIKit
+
+extension RecentSearchViewController {
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
+    
+    func recentCellRegistrationHandler(cell: RecentListCell, indexPath: IndexPath, item: String) {
+        if recents.isEmpty {
+            cell.isEmptyCell = true
+        } else {
+            cell.isEmptyCell = false
+            cell.text = item
+            cell.deleteAction = { [weak self] identifier in
+                let item = Item(recent: identifier)
+                self?.updateSnapshotForRecent(itemToDelete: item)
+            }
+        }
+    }
+    
+    func resultCellRegistrationHandler(cell: UICollectionViewListCell, indexPath: IndexPath, item: String) {
+        var configuration = UIListContentConfiguration.cell()
+        configuration.text = item
+        cell.contentConfiguration = configuration
+        cell.selectedBackgroundView = UIView()
+    }
+    
+    func titleSupplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
+        guard let section = Section(rawValue: indexPath.section) else {
+            fatalError("Unknown Section")
+        }
+        supplementaryView.title = section.title
+    }
+    
+    func initialSnapshot() {
+        let recentItems = recents.isEmpty ? [Item()] : recents.map({ Item(recent: $0) })
+        let resultItems = samples.map({ Item(result: $0.title) })
+        
+        snapshot = Snapshot()
+        snapshot.appendSections([.recent, .result])
+        snapshot.appendItems(recentItems, toSection: .recent)
+        snapshot.appendItems(resultItems, toSection: .result)
+        dataSource.apply(snapshot)
+    }
+    
+    func updateSnapshotForRecent(itemToDelete item: Item) {
+        guard let index = recents.firstIndex(of: item.recent!) else { return }
+        recents.remove(at: index)
+        snapshot.deleteItems([item])
+        dataSource.apply(snapshot)
+        
+        if recents.isEmpty {
+            emptySnapshotForRecent()
+        }
+    }
+    
+    func updateSnapshotForRecent(itemToAdd item: Item) {
+        if let first = recents.first {
+            let firstItem = Item(recent: first)
+            snapshot.insertItems([item], beforeItem: firstItem)
+        } else {
+            let recentItems = snapshot.itemIdentifiers(inSection: .recent)
+            snapshot.deleteItems(recentItems)
+            snapshot.appendItems([item], toSection: .recent)
+        }
+        recents.insert(item.recent!, at: 0)
+        dataSource.apply(snapshot)
+    }
+    
+    func emptySnapshotForRecent() {
+        snapshot.appendItems([Item()], toSection: .recent)
+        dataSource.apply(snapshot)
+    }
+    
+    func emptySnashotForResult() {
+        let resultItems = snapshot.itemIdentifiers(inSection: .result)
+        snapshot.deleteItems(resultItems)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    func filteredSnapshot(searchWord word: String) {
+        let resultItems = snapshot.itemIdentifiers(inSection: .result)
+        let filteredItems = samples
+            .map({ Item(result: $0.title) })
+            .filter{ $0.result!.contains(word) }
+        snapshot.deleteItems(resultItems)
+        snapshot.appendItems(filteredItems, toSection: .result)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Delegate.swift
@@ -12,6 +12,9 @@ extension RecentSearchViewController: UISearchBarDelegate {
         searchBar.resignFirstResponder()
         if let searchWord = searchBar.text {
             filteredSnapshot(searchWord: searchWord)
+            
+            let userInfo = UserInfo(nickname: searchWord)
+            guard !recents.contains(userInfo) else { return }
             let item = Item(recent: UserInfo(nickname: searchWord))
             updateSnapshotForRecent(itemToAdd: item)
         }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Delegate.swift
@@ -1,0 +1,27 @@
+//
+//  RecentSearchViewController+Delegate.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/23/24.
+//
+
+import UIKit
+
+extension RecentSearchViewController: UISearchBarDelegate {
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+        if let searchWord = searchBar.text {
+            filteredSnapshot(searchWord: searchWord)
+            let item = Item(recent: searchWord)
+            updateSnapshotForRecent(itemToAdd: item)
+        }
+    }
+    
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        initialSnapshot()
+    }
+    
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        emptySnashotForResult()
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Delegate.swift
@@ -12,7 +12,7 @@ extension RecentSearchViewController: UISearchBarDelegate {
         searchBar.resignFirstResponder()
         if let searchWord = searchBar.text {
             filteredSnapshot(searchWord: searchWord)
-            let item = Item(recent: searchWord)
+            let item = Item(recent: UserInfo(nickname: searchWord))
             updateSnapshotForRecent(itemToAdd: item)
         }
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+ListLayout.swift
@@ -1,0 +1,59 @@
+//
+//  RecentSearchViewController+ListLayout.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/24/24.
+//
+
+import UIKit
+
+extension RecentSearchViewController {
+    func layout() -> UICollectionViewLayout {
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        configuration.interSectionSpacing = 10
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProviderHandler, configuration: configuration)
+    }
+    
+    func sectionProviderHandler(sectionIndex: Int, layourEnviroment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        guard let section = Section(rawValue: sectionIndex) else {
+            fatalError("Unknown Section")
+        }
+        switch section {
+        case .recent:
+            return sectionForRecent(layoutEnviroment: layourEnviroment)
+        case .result:
+            return sectionForResult(layoutEnviroment: layourEnviroment)
+        }
+    }
+    
+    func sectionForRecent(layoutEnviroment enviroment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        let preferredContentSize = PreferredContentSizeManager.shared.size
+        
+        let itemSize = NSCollectionLayoutSize(widthDimension: .estimated(10), heightDimension: .fractionalHeight(1.0))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .estimated(10), heightDimension: .estimated(CGFloat(preferredContentSize * 10)))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = 10.0
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        return section
+        
+    }
+    
+    func sectionForResult(layoutEnviroment enviroment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        let configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+         let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: enviroment)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        return section
+    }
+    
+    func titleBoundarySupplementaryItem() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let titleSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .estimated(50))
+        return NSCollectionLayoutBoundarySupplementaryItem(layoutSize: titleSize, elementKind: "title-element-kind", alignment: .top)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Type.swift
@@ -22,10 +22,10 @@ extension RecentSearchViewController {
     }
     
     struct Item: Hashable {
-        let recent: String?
-        let result: String?
+        let recent: UserInfo?
+        let result: UserInfo?
         
-        init(recent: String?, result: String?) {
+        init(recent: UserInfo?, result: UserInfo?) {
             self.recent = recent
             self.result = result
         }
@@ -34,11 +34,11 @@ extension RecentSearchViewController {
             self.init(recent: nil, result: nil)
         }
         
-        init(recent: String) {
+        init(recent: UserInfo) {
             self.init(recent: recent, result: nil)
         }
         
-        init(result: String) {
+        init(result: UserInfo) {
             self.init(recent: nil, result: result)
         }
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Type.swift
@@ -1,0 +1,45 @@
+//
+//  RecentSearchViewController+Type.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/24/24.
+//
+
+import Foundation
+
+extension RecentSearchViewController {
+    enum Section: Int {
+        case recent, result
+        
+        var title: String {
+            switch self {
+            case .recent:
+                return "최근 검색어"
+            case .result:
+                return "검색 결과"
+            }
+        }
+    }
+    
+    struct Item: Hashable {
+        let recent: String?
+        let result: String?
+        
+        init(recent: String?, result: String?) {
+            self.recent = recent
+            self.result = result
+        }
+        
+        init() {
+            self.init(recent: nil, result: nil)
+        }
+        
+        init(recent: String) {
+            self.init(recent: recent, result: nil)
+        }
+        
+        init(result: String) {
+            self.init(recent: nil, result: result)
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Updating.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController+Updating.swift
@@ -1,0 +1,17 @@
+//
+//  RecentSearchViewController+Updating.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/23/24.
+//
+
+import UIKit
+
+extension RecentSearchViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        
+        if let searchWord = searchController.searchBar.text, !searchWord.isEmpty {
+            filteredSnapshot(searchWord: searchWord)
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
@@ -11,8 +11,8 @@ final class RecentSearchViewController: DefaultViewController {
     
     var dataSource: DataSource!
     var snapshot: Snapshot!
-    let samples = Book.samples
-    var recents = ["하퍼", "올리", "하니", "아일라", "이든", "아마라", "칸", "아주 긴 닉네임을 테스트 합니다"]
+    let allUsers = UserInfo.samples
+    var recents = UserInfo.recents
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     lazy var searchController = UISearchController()
@@ -45,10 +45,11 @@ extension RecentSearchViewController {
                 if let recent = itemIdentifier.recent {
                     return collectionView.dequeueConfiguredReusableCell(using: recentCellRegistration, for: indexPath, item: recent)
                 } else {
-                    return collectionView.dequeueConfiguredReusableCell(using: recentEmptyCellRegistration, for: indexPath, item: String())
+                    return collectionView.dequeueConfiguredReusableCell(using: recentEmptyCellRegistration, for: indexPath, item: Item())
                 }
             case .result:
-                return collectionView.dequeueConfiguredReusableCell(using: resultCellRegistration, for: indexPath, item: itemIdentifier.result ?? "")
+                guard let userInfo = itemIdentifier.result else { return UICollectionViewCell() }
+                return collectionView.dequeueConfiguredReusableCell(using: resultCellRegistration, for: indexPath, item: userInfo)
             }
         })
         

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
@@ -15,7 +15,7 @@ final class RecentSearchViewController: DefaultViewController {
     var recents = ["하퍼", "올리", "하니", "아일라", "이든", "아마라", "칸", "아주 긴 닉네임을 테스트 합니다"]
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
-    private lazy var searchController = UISearchController()
+    lazy var searchController = UISearchController()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
@@ -33,6 +33,7 @@ extension RecentSearchViewController {
         collectionView.contentInset = UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)
         
         let recentCellRegistration = UICollectionView.CellRegistration(handler: recentCellRegistrationHandler)
+        let recentEmptyCellRegistration = UICollectionView.CellRegistration(handler: recentEmptyCellRegistrationHandler)
         let resultCellRegistration = UICollectionView.CellRegistration(handler: resultCellRegistrationHandler)
         
         dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
@@ -41,7 +42,11 @@ extension RecentSearchViewController {
             }
             switch section {
             case .recent:
-                return collectionView.dequeueConfiguredReusableCell(using: recentCellRegistration, for: indexPath, item: itemIdentifier.recent ?? "")
+                if let recent = itemIdentifier.recent {
+                    return collectionView.dequeueConfiguredReusableCell(using: recentCellRegistration, for: indexPath, item: recent)
+                } else {
+                    return collectionView.dequeueConfiguredReusableCell(using: recentEmptyCellRegistration, for: indexPath, item: String())
+                }
             case .result:
                 return collectionView.dequeueConfiguredReusableCell(using: resultCellRegistration, for: indexPath, item: itemIdentifier.result ?? "")
             }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchViewController/RecentSearchViewController.swift
@@ -1,0 +1,85 @@
+//
+//  RecentSearchViewController.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/23/24.
+//
+
+import UIKit
+
+final class RecentSearchViewController: DefaultViewController {
+    
+    var dataSource: DataSource!
+    var snapshot: Snapshot!
+    let samples = Book.samples
+    var recents = ["하퍼", "올리", "하니", "아일라", "이든", "아마라", "칸", "아주 긴 닉네임을 테스트 합니다"]
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    private lazy var searchController = UISearchController()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        isSettingFocus = false
+        configureSubviews()
+        configureView()
+        configureConstraints()
+    }
+}
+
+// MARK: Configuration
+extension RecentSearchViewController {
+    
+    func configureSubviews() {
+        collectionView.contentInset = UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)
+        
+        let recentCellRegistration = UICollectionView.CellRegistration(handler: recentCellRegistrationHandler)
+        let resultCellRegistration = UICollectionView.CellRegistration(handler: resultCellRegistrationHandler)
+        
+        dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            guard let section = Section(rawValue: indexPath.section) else {
+                fatalError("Unknown Error")
+            }
+            switch section {
+            case .recent:
+                return collectionView.dequeueConfiguredReusableCell(using: recentCellRegistration, for: indexPath, item: itemIdentifier.recent ?? "")
+            case .result:
+                return collectionView.dequeueConfiguredReusableCell(using: resultCellRegistration, for: indexPath, item: itemIdentifier.result ?? "")
+            }
+        })
+        
+        let titleSupplementaryRegistration = UICollectionView.SupplementaryRegistration(elementKind: "title-element-kind", handler: titleSupplementaryRegistrationHandler)
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: titleSupplementaryRegistration, for: indexPath)
+            
+        }
+        
+        initialSnapshot()
+        collectionView.dataSource = dataSource
+    }
+    
+    func configureView() {
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+        
+        searchController.searchResultsUpdater = self
+        searchController.searchBar.delegate = self
+        searchController.searchBar.placeholder = "책 제목을 입력하세요"
+    }
+    
+    func configureConstraints() {
+        [ collectionView ]
+            .forEach{
+                $0.translatesAutoresizingMaskIntoConstraints = false
+                view.addSubview($0)
+            }
+        
+        let safeArea = view.safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
+        ])
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
@@ -37,6 +37,19 @@ extension RecentSearchWithAccessibilityViewController {
             fatalError("Unknown Section")
         }
         supplementaryView.title = section.title
+        
+        if UIAccessibility.isVoiceOverRunning {
+            supplementaryView.isAccessibilityElement = true
+            supplementaryView.accessibilityLabel = section.title
+            supplementaryView.accessibilityTraits = .header
+            
+            switch section {
+            case .recent:
+                supplementaryView.accessibilityValue = "\(self.recents.count)개의 검색어"
+            case .result:
+                break
+            }
+        }
     }
     
     func initialSnapshot() {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
@@ -1,0 +1,97 @@
+//
+//  RecentSearchWithAccessibilityViewController+DataSource.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+import UIKit
+
+extension RecentSearchWithAccessibilityViewController {
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
+    
+    func recentCellRegistrationHandler(cell: RecentListCell, indexPath: IndexPath, item: UserInfo) {
+        cell.text = item.nickname
+        cell.deleteAction = { [weak self]  in
+            let itemToDelete = Item(recent: item)
+            self?.updateSnapshotForRecent(itemToDelete: itemToDelete)
+        }
+        cell.textAction = { [weak self] searchWord in
+            self?.searchController.searchBar.text = searchWord
+        }
+    }
+    
+    func recentEmptyCellRegistrationHandler(cell: RecentEmptyListCell, indexPath: IndexPath, item: Item) {
+    }
+    
+    func resultCellRegistrationHandler(cell: UICollectionViewListCell, indexPath: IndexPath, item: UserInfo) {
+        var configuration = UIListContentConfiguration.cell()
+        configuration.text = item.nickname
+        cell.contentConfiguration = configuration
+        cell.selectedBackgroundView = UIView()
+    }
+    
+    func titleSupplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
+        guard let section = Section(rawValue: indexPath.section) else {
+            fatalError("Unknown Section")
+        }
+        supplementaryView.title = section.title
+    }
+    
+    func initialSnapshot() {
+        let recentItems = recents.isEmpty ? [Item()] : recents.map({ Item(recent: $0) })
+        let resultItems = allUsers.map({ Item(result: $0) })
+        
+        snapshot = Snapshot()
+        snapshot.appendSections([.recent, .result])
+        snapshot.appendItems(recentItems, toSection: .recent)
+        snapshot.appendItems(resultItems, toSection: .result)
+        dataSource.apply(snapshot)
+    }
+    
+    func updateSnapshotForRecent(itemToDelete item: Item) {
+        guard let index = recents.firstIndex(of: item.recent!) else { return }
+        recents.remove(at: index)
+        snapshot.deleteItems([item])
+        dataSource.apply(snapshot)
+        
+        if recents.isEmpty {
+            emptySnapshotForRecent()
+        }
+    }
+    
+    func updateSnapshotForRecent(itemToAdd item: Item) {
+        if let first = recents.first {
+            let firstItem = Item(recent: first)
+            snapshot.insertItems([item], beforeItem: firstItem)
+        } else {
+            let recentItems = snapshot.itemIdentifiers(inSection: .recent)
+            snapshot.deleteItems(recentItems)
+            snapshot.appendItems([item], toSection: .recent)
+        }
+        recents.insert(item.recent!, at: 0)
+        dataSource.apply(snapshot)
+    }
+    
+    func emptySnapshotForRecent() {
+        snapshot.appendItems([Item()], toSection: .recent)
+        dataSource.apply(snapshot)
+    }
+    
+    func emptySnashotForResult() {
+        let resultItems = snapshot.itemIdentifiers(inSection: .result)
+        snapshot.deleteItems(resultItems)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    func filteredSnapshot(searchWord word: String) {
+        let resultItems = snapshot.itemIdentifiers(inSection: .result)
+        let filteredItems = allUsers
+            .map({ Item(result: $0) })
+            .filter{ $0.result!.nickname.contains(word) }
+        snapshot.deleteItems(resultItems)
+        snapshot.appendItems(filteredItems, toSection: .result)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
@@ -55,6 +55,7 @@ extension RecentSearchWithAccessibilityViewController {
         recents.remove(at: index)
         snapshot.deleteItems([item])
         dataSource.apply(snapshot)
+        accessibilityAnnounceRecent(for: item)
         
         if recents.isEmpty {
             emptySnapshotForRecent()
@@ -103,6 +104,16 @@ extension RecentSearchWithAccessibilityViewController {
             Task {
                 await UIAccessibility.announceString(for: annuouncement)
             }
+        }
+    }
+    
+    func accessibilityAnnounceRecent(for item: Item) {
+        guard UIAccessibility.isVoiceOverRunning,
+              let nickname = item.recent?.nickname else { return }
+        let announcement = "\(nickname) 제거됨"
+        
+        Task {
+            await UIAccessibility.announceString(for: announcement)
         }
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
@@ -93,5 +93,16 @@ extension RecentSearchWithAccessibilityViewController {
         snapshot.deleteItems(resultItems)
         snapshot.appendItems(filteredItems, toSection: .result)
         dataSource.apply(snapshot, animatingDifferences: true)
+        
+        accessibilityAnnounceSearchResult(for: filteredItems)
+    }
+    
+    func accessibilityAnnounceSearchResult(for list: [Item]) {
+        if UIAccessibility.isVoiceOverRunning {
+            let annuouncement = "\(list.count)개 검색 결과 제안됨"
+            Task {
+                await UIAccessibility.announceString(for: annuouncement)
+            }
+        }
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Delegate.swift
@@ -1,0 +1,30 @@
+//
+//  RecentSearchWithAccessibilityViewController+Delegate.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+import UIKit
+
+extension RecentSearchWithAccessibilityViewController: UISearchBarDelegate {
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+        if let searchWord = searchBar.text {
+            filteredSnapshot(searchWord: searchWord)
+            
+            let userInfo = UserInfo(nickname: searchWord)
+            guard !recents.contains(userInfo) else { return }
+            let item = Item(recent: UserInfo(nickname: searchWord))
+            updateSnapshotForRecent(itemToAdd: item)
+        }
+    }
+    
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        initialSnapshot()
+    }
+    
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        emptySnashotForResult()
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Delegate.swift
@@ -17,6 +17,13 @@ extension RecentSearchWithAccessibilityViewController: UISearchBarDelegate {
             guard !recents.contains(userInfo) else { return }
             let item = Item(recent: UserInfo(nickname: searchWord))
             updateSnapshotForRecent(itemToAdd: item)
+            
+            if UIAccessibility.isVoiceOverRunning,
+               let resultHeader = collectionView.supplementaryView(forElementKind: headerSupplementaryKind, at: IndexPath(item: 0, section: 1)) {
+                Task {
+                    try? await UIAccessibility.setFocus(to: resultHeader)
+                }
+            }
         }
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+ListLayout.swift
@@ -1,0 +1,59 @@
+//
+//  RecentSearchWithAccessibilityViewController+ListLayout.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+import UIKit
+
+extension RecentSearchWithAccessibilityViewController {
+    func layout() -> UICollectionViewLayout {
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        configuration.interSectionSpacing = 10
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProviderHandler, configuration: configuration)
+    }
+    
+    func sectionProviderHandler(sectionIndex: Int, layourEnviroment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        guard let section = Section(rawValue: sectionIndex) else {
+            fatalError("Unknown Section")
+        }
+        switch section {
+        case .recent:
+            return sectionForRecent(layoutEnviroment: layourEnviroment)
+        case .result:
+            return sectionForResult(layoutEnviroment: layourEnviroment)
+        }
+    }
+    
+    func sectionForRecent(layoutEnviroment enviroment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        let preferredContentSize = PreferredContentSizeManager.shared.size
+        
+        let itemSize = NSCollectionLayoutSize(widthDimension: .estimated(10), heightDimension: .fractionalHeight(1.0))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .estimated(10), heightDimension: .estimated(CGFloat(preferredContentSize * 10)))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = 10.0
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        return section
+        
+    }
+    
+    func sectionForResult(layoutEnviroment enviroment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        let configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+         let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: enviroment)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        return section
+    }
+    
+    func titleBoundarySupplementaryItem() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let titleSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .estimated(50))
+        return NSCollectionLayoutBoundarySupplementaryItem(layoutSize: titleSize, elementKind: "title-element-kind", alignment: .top)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Type.swift
@@ -1,0 +1,45 @@
+//
+//  RecentSearchWithAccessibilityViewController+Type.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+import Foundation
+
+extension RecentSearchWithAccessibilityViewController {
+    enum Section: Int {
+        case recent, result
+        
+        var title: String {
+            switch self {
+            case .recent:
+                return "최근 검색어"
+            case .result:
+                return "검색 결과"
+            }
+        }
+    }
+    
+    struct Item: Hashable {
+        let recent: UserInfo?
+        let result: UserInfo?
+        
+        init(recent: UserInfo?, result: UserInfo?) {
+            self.recent = recent
+            self.result = result
+        }
+        
+        init() {
+            self.init(recent: nil, result: nil)
+        }
+        
+        init(recent: UserInfo) {
+            self.init(recent: recent, result: nil)
+        }
+        
+        init(result: UserInfo) {
+            self.init(recent: nil, result: result)
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Updating.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+Updating.swift
@@ -1,0 +1,17 @@
+//
+//  RecentSearchWithAccessibilityViewController+Updating.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+import UIKit
+
+extension RecentSearchWithAccessibilityViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        
+        if let searchWord = searchController.searchBar.text, !searchWord.isEmpty {
+            filteredSnapshot(searchWord: searchWord)
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
@@ -19,7 +19,6 @@ final class RecentSearchWithAccessibilityViewController: DefaultViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        isSettingFocus = false
         configureSubviews()
         configureView()
         configureConstraints()

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class RecentSearchWithAccessibilityViewController: DefaultViewController {
     
+    let headerSupplementaryKind = "title-element-kind"
+    
     var dataSource: DataSource!
     var snapshot: Snapshot!
     let allUsers = UserInfo.samples
@@ -56,7 +58,7 @@ extension RecentSearchWithAccessibilityViewController {
             }
         })
         
-        let titleSupplementaryRegistration = UICollectionView.SupplementaryRegistration(elementKind: "title-element-kind", handler: titleSupplementaryRegistrationHandler)
+        let titleSupplementaryRegistration = UICollectionView.SupplementaryRegistration(elementKind: headerSupplementaryKind, handler: titleSupplementaryRegistrationHandler)
         dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
             return collectionView.dequeueConfiguredReusableSupplementary(using: titleSupplementaryRegistration, for: indexPath)
         }
@@ -66,7 +68,7 @@ extension RecentSearchWithAccessibilityViewController {
     }
     
     func accessibilityValueForRecentSupplementary() {
-        guard let supplementaryView = collectionView.supplementaryView(forElementKind: "title-element-kind", at: IndexPath(item: 0, section: 0)) as? TitleSupplementaryView else { return }
+        guard let supplementaryView = collectionView.supplementaryView(forElementKind: headerSupplementaryKind, at: IndexPath(item: 0, section: 0)) as? TitleSupplementaryView else { return }
         supplementaryView.accessibilityValue = "\(self.recents.count)개의 검색어"
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
@@ -58,17 +58,7 @@ extension RecentSearchWithAccessibilityViewController {
         
         let titleSupplementaryRegistration = UICollectionView.SupplementaryRegistration(elementKind: "title-element-kind", handler: titleSupplementaryRegistrationHandler)
         dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
-            let supplementaryView = collectionView.dequeueConfiguredReusableSupplementary(using: titleSupplementaryRegistration, for: indexPath)
-            if UIAccessibility.isVoiceOverRunning,
-               let section = Section(rawValue: indexPath.section) {
-                switch section {
-                case .recent:
-                    supplementaryView.accessibilityValue = "\(self.recents.count)개의 검색어가 있습니다."
-                case .result:
-                    break
-                }
-            }
-            return supplementaryView
+            return collectionView.dequeueConfiguredReusableSupplementary(using: titleSupplementaryRegistration, for: indexPath)
         }
         
         initialSnapshot()
@@ -77,7 +67,7 @@ extension RecentSearchWithAccessibilityViewController {
     
     func accessibilityValueForRecentSupplementary() {
         guard let supplementaryView = collectionView.supplementaryView(forElementKind: "title-element-kind", at: IndexPath(item: 0, section: 0)) as? TitleSupplementaryView else { return }
-        supplementaryView.accessibilityValue = "\(self.recents.count)개의 검색어가 있습니다."
+        supplementaryView.accessibilityValue = "\(self.recents.count)개의 검색어"
     }
     
     func configureView() {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
@@ -1,0 +1,91 @@
+//
+//  RecentSearchWithAccessibilityViewController.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/25/24.
+//
+
+import UIKit
+
+final class RecentSearchWithAccessibilityViewController: DefaultViewController {
+    
+    var dataSource: DataSource!
+    var snapshot: Snapshot!
+    let allUsers = UserInfo.samples
+    var recents = UserInfo.recents
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    lazy var searchController = UISearchController()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        isSettingFocus = false
+        configureSubviews()
+        configureView()
+        configureConstraints()
+    }
+}
+
+// MARK: Configuration
+extension RecentSearchWithAccessibilityViewController {
+    
+    func configureSubviews() {
+        collectionView.contentInset = UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)
+        
+        let recentCellRegistration = UICollectionView.CellRegistration(handler: recentCellRegistrationHandler)
+        let recentEmptyCellRegistration = UICollectionView.CellRegistration(handler: recentEmptyCellRegistrationHandler)
+        let resultCellRegistration = UICollectionView.CellRegistration(handler: resultCellRegistrationHandler)
+        
+        dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            guard let section = Section(rawValue: indexPath.section) else {
+                fatalError("Unknown Error")
+            }
+            switch section {
+            case .recent:
+                if let recent = itemIdentifier.recent {
+                    return collectionView.dequeueConfiguredReusableCell(using: recentCellRegistration, for: indexPath, item: recent)
+                } else {
+                    return collectionView.dequeueConfiguredReusableCell(using: recentEmptyCellRegistration, for: indexPath, item: Item())
+                }
+            case .result:
+                guard let userInfo = itemIdentifier.result else { return UICollectionViewCell() }
+                return collectionView.dequeueConfiguredReusableCell(using: resultCellRegistration, for: indexPath, item: userInfo)
+            }
+        })
+        
+        let titleSupplementaryRegistration = UICollectionView.SupplementaryRegistration(elementKind: "title-element-kind", handler: titleSupplementaryRegistrationHandler)
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: titleSupplementaryRegistration, for: indexPath)
+            
+        }
+        
+        initialSnapshot()
+        collectionView.dataSource = dataSource
+    }
+    
+    func configureView() {
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+        
+        searchController.searchResultsUpdater = self
+        searchController.searchBar.delegate = self
+        searchController.searchBar.placeholder = "책 제목을 입력하세요"
+    }
+    
+    func configureConstraints() {
+        [ collectionView ]
+            .forEach{
+                $0.translatesAutoresizingMaskIntoConstraints = false
+                view.addSubview($0)
+            }
+        
+        let safeArea = view.safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
+        ])
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/DefaultCollectionViewController/DefaultCollectionViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/DefaultCollectionViewController/DefaultCollectionViewController+DataSource.swift
@@ -20,9 +20,6 @@ extension DefaultCollectionViewController {
         cell.selectedBackgroundView = UIView()
         cell.view.addSubview(item.view)
         cell.tagLabel.text = item.tag.title
-        if UIAccessibility.isVoiceOverRunning {
-            cell.tagLabel.accessibilityLabel = item.tag.accessibilityLabel
-        }
         
         item.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/TitleSupplementaryView.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/TitleSupplementaryView.swift
@@ -15,6 +15,12 @@ class TitleSupplementaryView: UICollectionReusableView {
         }
     }
     
+    override var accessibilityValue: String? {
+        didSet {
+            titleLabel.accessibilityValue = accessibilityValue
+        }
+    }
+    
     private lazy var titleLabel = UILabel()
     
     override init(frame: CGRect) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/TitleSupplementaryView.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/TitleSupplementaryView.swift
@@ -15,12 +15,6 @@ class TitleSupplementaryView: UICollectionReusableView {
         }
     }
     
-    override var accessibilityValue: String? {
-        didSet {
-            titleLabel.accessibilityValue = accessibilityValue
-        }
-    }
-    
     private lazy var titleLabel = UILabel()
     
     override init(frame: CGRect) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/UIAccessibility+.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/UIAccessibility+.swift
@@ -14,4 +14,10 @@ extension UIAccessibility {
         try await Task.sleep(for: duration)
         UIAccessibility.post(notification: .layoutChanged, argument: object)
     }
+    
+    @MainActor
+        static func announceString(for str: String) async {
+            try? await Task.sleep(for: .seconds(0.1))
+            UIAccessibility.post(notification: .announcement, argument: str)
+        }
 }


### PR DESCRIPTION
## UI / 기능
- 화면 UI 구성
- suggest
- 검색어 입력 검색
- 최근 검색어 삭제
- 최근 검색어 선택 시 검색
- 최근 검색어 데이터 없을 경우 안내 문구 표시

<br>

## 접근성 개선
- '뒤로 가기'에 시작 초점 설정
- 검색 결과 개수 안내
- 최근 검색어 제거 시 음성 출력
- '최근 검색어' 머리말에 개수 안내
- 검색 버튼 Tap할 경우 '검색 결과' 머리말로 초점 이동

<br>


## 이외
- AccessibilityLabel을 위해 구현했던 컴포넌트 기호 제거 로직 삭제
   - 이유) 화면상 표시되는 정보를 그대로 출력해야함



<br>

## 미리보기
| 최근 검색어 머리말 | 최근 검색어 제거 동작시 안내 | 검색 suggest |
| ----- | ----- | ----- |
|  <img src = "https://github.com/user-attachments/assets/a0bc59e6-8319-4613-bbce-7434b7521d03" width = 200 height = 400> |  <img src = "https://github.com/user-attachments/assets/1bcb49a3-7bd3-4685-bf51-44c91cd8729c" width = 200 height = 400> |   <img src = "https://github.com/user-attachments/assets/eb1e8445-7bb0-4853-b1a9-8fd20ab3995b" width = 200 height = 400>  |


## 미리보기
| 검색 후 초점 이동 | 최근 검색어 없을 경우 |
| ----- | ----- |
|  <img src = "https://github.com/user-attachments/assets/b68d88a1-63f3-43b7-a7ea-c1ebc2bfc6b2" width = 200 height = 400>  |   <img src = "https://github.com/user-attachments/assets/511bc9b8-eb9c-4b61-88f2-5178b08d5f69" width = 200 height = 400> |



<br>


#73 

