### PR TITLE
[ Outline ] feat: accessibilityTriats 구분

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		4ECD49812C8E9B6200F3BEC7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4ECD49802C8E9B6200F3BEC7 /* Assets.xcassets */; };
 		4ECD49842C8E9B6200F3BEC7 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 4ECD49832C8E9B6200F3BEC7 /* Base */; };
 		4ECD498E2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD498D2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift */; };
+		4ED2C90B2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED2C90A2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift */; };
 		4ED71CE52CA6392F00A1A724 /* AccessibilityListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED71CE42CA6392F00A1A724 /* AccessibilityListCell.swift */; };
 		4EEEE6132CC0D9B500FCF08B /* ChartCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */; };
 		4EEEE6172CC0DC2500FCF08B /* LatestCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */; };
@@ -252,6 +253,7 @@
 		4ECD49832C8E9B6200F3BEC7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4ECD49852C8E9B6200F3BEC7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4ECD498D2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonAndSliderViewController.swift; sourceTree = "<group>"; };
+		4ED2C90A2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTraitsCollectionListCell.swift; sourceTree = "<group>"; };
 		4ED71CE42CA6392F00A1A724 /* AccessibilityListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityListCell.swift; sourceTree = "<group>"; };
 		4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartCollectionListCell.swift; sourceTree = "<group>"; };
 		4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestCollectionListCell.swift; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 				4E1BC4F82CAF87F9001A29D5 /* UIAccessibility+.swift */,
 				14852BE62CC20B4300F53857 /* ButtonTraitsTableCell.swift */,
 				1488352D2CC50B0B0015EA41 /* ButtonTraitsCollectionListCell.swift */,
+				4ED2C90A2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -789,6 +792,7 @@
 				4EEEE6132CC0D9B500FCF08B /* ChartCollectionListCell.swift in Sources */,
 				4E0AB03F2C9BAB9700B8A89C /* Detail.swift in Sources */,
 				4E855F542CACE15C008CDB3B /* DefaultCollectionViewController.swift in Sources */,
+				4ED2C90B2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift in Sources */,
 				4E855F582CACE1C0008CDB3B /* DefaultCollectionViewController+ListLayout.swift in Sources */,
 				4EC52AE92CA0F53A007E07D6 /* StateViewController+Delegate.swift in Sources */,
 				14F7FC402CB2C8D300F3FA61 /* SearchViewControllerWithAccessibility+DataSource.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+DataSource.swift
@@ -13,7 +13,7 @@ extension OutlineViewController {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Outline, Detail>
     typealias SectionSnapshot = NSDiffableDataSourceSectionSnapshot<Detail>
     
-    func headerRegistrationHandler(cell: ButtonTraitsCollectionListCell, indexPath: IndexPath, item: Detail) {
+    func headerRegistrationHandler(cell: HeaderTraitsCollectionListCell, indexPath: IndexPath, item: Detail) {
         var configuration = cell.defaultContentConfiguration()
         configuration.text = item.title
         cell.contentConfiguration = configuration

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutlineViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutlineViewController.swift
@@ -51,7 +51,7 @@ private extension OutlineViewController {
 // MARK: CollectionView Layout
 private extension OutlineViewController {
     func layout() -> UICollectionViewLayout {
-        var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        let configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
         return UICollectionViewCompositionalLayout.list(using: configuration)
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutlineViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutlineViewController.swift
@@ -44,20 +44,7 @@ private extension OutlineViewController {
     }
     
     func configureConstraints() {
-        [ collectionView ]
-            .forEach{
-                $0.translatesAutoresizingMaskIntoConstraints = false
-                view.addSubview($0)
-            }
-        
-        let safeArea = view.safeAreaLayoutGuide
-        
-        NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: safeArea.topAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
-        ])
+        view.addPinnedSubview(collectionView, height: nil)
     }
 }
 

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/HeaderTraitsCollectionListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/HeaderTraitsCollectionListCell.swift
@@ -1,0 +1,15 @@
+//
+//  HeaderTraitsCollectionListCell.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/28/24.
+//
+
+import UIKit
+
+class HeaderTraitsCollectionListCell: UICollectionViewListCell {
+    override var accessibilityTraits: UIAccessibilityTraits {
+        get { .header }
+        set {}
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/View+Constraints.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/View+Constraints.swift
@@ -25,7 +25,7 @@ extension UIView {
         
         NSLayoutConstraint.activate([
             view.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: inset.top),
-            view.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: inset.bottom),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: inset.bottom),
             view.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: inset.left),
             view.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: inset.right)
         ])


### PR DESCRIPTION

- 각 Cell 별 accessibilityTriats 구분
    - header
    - button

- UI 하단 constraints 조정
    - UIView+: addPinnedSubview(_ :, inset:, height:)의 하단 constraints 변경


<br>

<br>

## 미리보기
| 머리말 | 버튼 | constraints 조정 |
| ----- | ----- | ----- |
|  <img src = "https://github.com/user-attachments/assets/1ebf2c4f-71d1-4001-9157-ca150e1a4562" width = 200 height = 400> |  <img src = "https://github.com/user-attachments/assets/06af307c-3338-47d7-904b-5931ee39e9f7" width = 200 height = 400> |   <img src = "https://github.com/user-attachments/assets/64b07661-f27c-4dd8-8c99-bc1f06358750" width = 200 height = 400>  |



<br>

<br>



#75