### PR TITLE
[ Search ] feat: 최근 검색어 피드백 반영

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		4ECD49842C8E9B6200F3BEC7 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 4ECD49832C8E9B6200F3BEC7 /* Base */; };
 		4ECD498E2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD498D2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift */; };
 		4ED2C90B2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED2C90A2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift */; };
+		4ED6AB172CD076C5001B630D /* RecentListCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED6AB162CD076C5001B630D /* RecentListCellWithAccessibility.swift */; };
 		4ED71CE52CA6392F00A1A724 /* AccessibilityListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED71CE42CA6392F00A1A724 /* AccessibilityListCell.swift */; };
 		4EEEE6132CC0D9B500FCF08B /* ChartCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */; };
 		4EEEE6172CC0DC2500FCF08B /* LatestCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */; };
@@ -254,6 +255,7 @@
 		4ECD49852C8E9B6200F3BEC7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4ECD498D2C8ECBDD00F3BEC7 /* ButtonAndSliderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonAndSliderViewController.swift; sourceTree = "<group>"; };
 		4ED2C90A2CCF1F1800AB40F8 /* HeaderTraitsCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTraitsCollectionListCell.swift; sourceTree = "<group>"; };
+		4ED6AB162CD076C5001B630D /* RecentListCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentListCellWithAccessibility.swift; sourceTree = "<group>"; };
 		4ED71CE42CA6392F00A1A724 /* AccessibilityListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityListCell.swift; sourceTree = "<group>"; };
 		4EEEE6122CC0D9B500FCF08B /* ChartCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartCollectionListCell.swift; sourceTree = "<group>"; };
 		4EEEE6162CC0DC2500FCF08B /* LatestCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestCollectionListCell.swift; sourceTree = "<group>"; };
@@ -333,6 +335,7 @@
 				149991B92CCB45DA0036BE94 /* RecentSearchWithAccessibilityViewController+ListLayout.swift */,
 				149991BB2CCB45E60036BE94 /* RecentSearchWithAccessibilityViewController+Updating.swift */,
 				149991BD2CCB45EF0036BE94 /* RecentSearchWithAccessibilityViewController+Type.swift */,
+				4ED6AB162CD076C5001B630D /* RecentListCellWithAccessibility.swift */,
 			);
 			path = RecentSearchWithAccessibilityViewController;
 			sourceTree = "<group>";
@@ -986,6 +989,7 @@
 				4EB123062CB7B57900D771D3 /* NewsListCellWithAccessibility.swift in Sources */,
 				4E855F5A2CACE209008CDB3B /* DefaultCollectionViewController+Type.swift in Sources */,
 				4EBB491B2CA3D63C006FD702 /* TextViewController+Delegate.swift in Sources */,
+				4ED6AB172CD076C5001B630D /* RecentListCellWithAccessibility.swift in Sources */,
 				14852BE72CC20B4300F53857 /* ButtonTraitsTableCell.swift in Sources */,
 				4EC52B062CA16CF5007E07D6 /* PageViewController+DataSource.swift in Sources */,
 				4EB122F82CB7679300D771D3 /* NewsListViewController.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -1142,7 +1142,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = ZQV4ZDQNW5;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "DefaultComponents-Accessibility/Info.plist";
+				INFOPLIST_FILE = "DefaultComponents-Accessibility/Resources/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
@@ -1170,7 +1170,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = ZQV4ZDQNW5;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "DefaultComponents-Accessibility/Info.plist";
+				INFOPLIST_FILE = "DefaultComponents-Accessibility/Resources/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchViewController/RecentSearchViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchViewController/RecentSearchViewController.swift
@@ -69,7 +69,7 @@ extension RecentSearchViewController {
         
         searchController.searchResultsUpdater = self
         searchController.searchBar.delegate = self
-        searchController.searchBar.placeholder = "책 제목을 입력하세요"
+        searchController.searchBar.placeholder = "닉네임을 입력하세요"
     }
     
     func configureConstraints() {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentListCellWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentListCellWithAccessibility.swift
@@ -1,0 +1,79 @@
+//
+//  RecentListCellWithAccessibility.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/29/24.
+//
+
+import UIKit
+
+final class RecentListCellWithAccessibility: ButtonTraitsCollectionListCell {
+    
+    var text: String = "닉네임" {
+        didSet {
+            textButtonConfig.title = text
+            textButton.configuration = textButtonConfig
+            deleteButton.accessibilityHint = text
+        }
+    }
+    var deleteAction: (() -> Void)?
+    var textAction: ((String) -> Void)?
+    
+    private var textButtonConfig = UIButton.Configuration.plain()
+    private lazy var textButton = UIButton()
+    private lazy var deleteButton = UIButton()
+    private lazy var stackView = UIStackView(arrangedSubviews: [textButton, deleteButton])
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureContentView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc func didTapDeleteButton() {
+        deleteAction?()
+    }
+    
+    @objc func didTapTextButton(_ sender: UIButton) {
+        guard let searchWord = sender.titleLabel?.text else { return }
+        textAction?(searchWord)
+    }
+}
+
+private extension RecentListCellWithAccessibility {
+    func configureContentView() {
+        backgroundView = UIView()
+        selectedBackgroundView = UIView()
+        
+        textButtonConfig.baseForegroundColor = .black
+        setPreferredFontyStyle()
+        textButton.addTarget(self, action: #selector(didTapTextButton), for: .touchUpInside)
+        
+        let deleteImage = UIImage(systemName: "xmark")
+        var config = UIButton.Configuration.plain()
+        config.image = deleteImage
+        config.baseForegroundColor = .black
+        config.buttonSize = .mini
+        deleteButton.configuration = config
+        deleteButton.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
+        deleteButton.accessibilityLabel = "제거"
+        
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 10
+        
+        contentView.addPinnedSubview(stackView, inset: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0), height: nil)
+    }
+}
+
+extension RecentListCellWithAccessibility: DynamicTypeable {
+    func setPreferredFontyStyle() {
+        textButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
@@ -11,7 +11,7 @@ extension RecentSearchWithAccessibilityViewController {
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
     
-    func recentCellRegistrationHandler(cell: RecentListCell, indexPath: IndexPath, item: UserInfo) {
+    func recentCellRegistrationHandler(cell: RecentListCellWithAccessibility, indexPath: IndexPath, item: UserInfo) {
         cell.text = item.nickname
         cell.deleteAction = { [weak self]  in
             let itemToDelete = Item(recent: item)

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController.swift
@@ -78,7 +78,7 @@ extension RecentSearchWithAccessibilityViewController {
         
         searchController.searchResultsUpdater = self
         searchController.searchBar.delegate = self
-        searchController.searchBar.placeholder = "책 제목을 입력하세요"
+        searchController.searchBar.placeholder = "닉네임을 입력하세요"
     }
     
     func configureConstraints() {


### PR DESCRIPTION
## 작업

- 최근 검색어 제거 동작 힌트 추가: "제거 버튼, 하퍼"
    - RecentListCellWithAccessibility를 생성해 접근성 준수 구분 
- 검색 필드 placeholder 정정

<br>

## 이슈
- 최근 검색어 삭제 시 뒷 순서 아이템(/제거버튼)으로 초점 이동 
    - 초점 이동 속도가 느려 사용에 불편함을 준다고 판단해 해당 작업을 중단했습니다.

<br>

## 미리보기
| 동작 힌트 추가 |
| ----- |
|  <img src = "https://github.com/user-attachments/assets/702845c6-f8f3-49a2-afc6-762cc7394d67" width = 200 height = 400>  |

<br>



<br>

#80 