### PR TITLE
[ Search ] feat: 최근 검색어 2차 피드백

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentListCellWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentListCellWithAccessibility.swift
@@ -13,6 +13,8 @@ final class RecentListCellWithAccessibility: ButtonTraitsCollectionListCell {
         didSet {
             textButtonConfig.title = text
             textButton.configuration = textButtonConfig
+            textButton.accessibilityLabel = text
+            textButton.accessibilityValue = "검색어로 입력"
             deleteButton.accessibilityHint = text
         }
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
@@ -38,19 +38,6 @@ extension RecentSearchWithAccessibilityViewController {
             fatalError("Unknown Section")
         }
         supplementaryView.title = section.title
-        
-        if UIAccessibility.isVoiceOverRunning {
-            supplementaryView.isAccessibilityElement = true
-            supplementaryView.accessibilityLabel = section.title
-            supplementaryView.accessibilityTraits = .header
-            
-            switch section {
-            case .recent:
-                supplementaryView.accessibilityValue = "\(self.recents.count)개의 검색어"
-            case .result:
-                break
-            }
-        }
     }
     
     func initialSnapshot() {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Controllers/Text/RecentSearchWithAccessibilityViewController/RecentSearchWithAccessibilityViewController+DataSource.swift
@@ -25,11 +25,12 @@ extension RecentSearchWithAccessibilityViewController {
     func recentEmptyCellRegistrationHandler(cell: RecentEmptyListCell, indexPath: IndexPath, item: Item) {
     }
     
-    func resultCellRegistrationHandler(cell: UICollectionViewListCell, indexPath: IndexPath, item: UserInfo) {
+    func resultCellRegistrationHandler(cell: ButtonTraitsCollectionListCell, indexPath: IndexPath, item: UserInfo) {
         var configuration = UIListContentConfiguration.cell()
         configuration.text = item.nickname
         cell.contentConfiguration = configuration
         cell.selectedBackgroundView = UIView()
+        cell.accessibilityLabel = item.nickname
     }
     
     func titleSupplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {


### PR DESCRIPTION

## 작업

- 최근 검색어 추가 정보 제거 
    - "4개의 검색어"
- 최근 검색어 아이템 동작 정보 추가 
    - "하퍼, 검색어로 입력, 버튼"
- "선택됨" 미제거 오류 수정

<br>

<br>

## 미리보기
| 동작 정보 추가 |
| ----- |
|  <img src = "https://github.com/user-attachments/assets/a1dd5585-32f9-41b3-9adf-296a310e5873" width = 200 height = 400>  |

<br>



<br>

#82